### PR TITLE
[ez] get workflows to run on prs

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -2,6 +2,7 @@ name: Ruff
 
 on:
   push:
+  pull_request:
 jobs:
   ruff:
     runs-on: ubuntu-latest

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -2,6 +2,7 @@ name: Smoke Test
 
 on:
   push:
+  pull_request:
 
 jobs:
   smoke-test:


### PR DESCRIPTION
This PR let's our tests run on prs (specifcally those that push code from a fork like [this](https://github.com/pytorch-labs/BackendBench/pull/38))