### PR TITLE
Add large inputs to our dataset

### DIFF
--- a/BackendBench/scripts/get_big_inputs.py
+++ b/BackendBench/scripts/get_big_inputs.py
@@ -43,6 +43,7 @@ SCRAPED_HF_URL = "https://huggingface.co/datasets/GPUMODE/huggingface_op_trace/r
 
 log = logging.getLogger(__name__)
 
+
 def cleanup_memory_and_gpu(*variables):
     """Helper function to delete variables and clean up GPU memory"""
     for var in variables:

--- a/BackendBench/torchbench_suite.py
+++ b/BackendBench/torchbench_suite.py
@@ -15,6 +15,22 @@ from BackendBench.utils import deserialize_args
 # ie. https://github.com/pytorch-labs/tritonbench/blob/main/tritonbench/data/input_configs/hf_train/AlbertForMaskedLM_training.txt
 DEFAULT_HUGGINGFACE_URL = "https://huggingface.co/datasets/GPUMODE/huggingface_op_trace/raw/main/augmented_hf_op_traces.txt"
 
+# Operators to skip for indexing ops that need valid indices
+SKIP_OPERATORS = [
+    "embedding",
+    "scatter",
+    "gather",
+    "index",
+    "nll_loss",
+    "im2col_backward",
+    "col2im_backward",
+    "native_layer_norm_backward",
+    "upsample_nearest2d_backward.vec",
+    "upsample_bilinear2d_backward.vec",
+    "_cudnn_rnn_backward.default",  # RuntimeError: cuDNN error: CUDNN_STATUS_BAD_PARAM
+    "_fft_c2c.default",  # cuFFT only supports dimensions whose sizes are powers of two when computing in half precision
+]
+
 
 class TorchBenchTest:
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
tl;dr address issue #36 

A major problem with KernelBench is that the input sizes are too small. Here we aim to explicitly fix this. 
`scripts/get_big_inputs.py` is introduced to take a file in the tritonbench format (right now [this one](https://huggingface.co/datasets/GPUMODE/huggingface_op_trace/blob/main/tritonbench_op_trace.txt)). Then for each operator we do the following for some number (in the case of this PR 5) of the largest test cases. We do this using a single H100.
1. Find an upper bound in which we hit an out of memory error by repeatedly doubling the shapes of the input tensors. We do this uniformly as we increase the size of all tensors found in the input by the same size.
2. Do a binary search (stopping at 100 iterations) to find the largest input we can stuff into the operator
3. Add in manually scaled tensors into the mix (explained in the note below)
4. Append that this new input into a master list
5. We then do a reverification using a simple forward pass to convince ourselves all of the of the inputs do actually work.
6. Spit out a final txt file of inputs.

Note: That the strategy of increasing the size of all of the tensors is not perfect as many ops have constraints on the shapes of the tensors that it takes in relation to itself. There were about 21 operators that I failed to scale using this methodology, so I made 2-3 manual sets of inputs for these. You can see them [here](https://huggingface.co/datasets/GPUMODE/huggingface_op_trace/blob/main/manually_scaled_op_traces.txt)

I updated the urls to link to the new [(augmented) dataset ](https://huggingface.co/datasets/GPUMODE/huggingface_op_trace/resolve/main/augmented_tritonbench_op_trace.txt)

Furthermore, as folks are likely curious here are the [new inputs ](https://gist.github.com/PaliC/d5ea54aa7a039488fa12155183a3bfc6)that were added

In theory you should be able to mostly reproduce the results on an H100 by just running `python BackendBench/scripts/get_big_inputs.py`. However, note that differences in gpus (and others using them) can cause a slight variation of when they OOM.

Some notes: Generally we set a limit of scaling at 1024x mostly because we still want the tensor to be small enough to run on a lot of things.

I wasn't able to scale the following op:  {'aten.unfold_backward.default'}, however, we can fix this specific one later

