### PR TITLE
[EZ] Check for stable outputs

### DIFF
--- a/BackendBench/utils.py
+++ b/BackendBench/utils.py
@@ -153,3 +153,15 @@ def deserialize_args(inps):
     for key in dtype_abbrs_parsing:
         inps = inps.replace(f"'{key}'", key)
     return eval(inps.strip().strip("'").strip('"'), global_vals)
+
+
+def check_for_stable_output(op, inps, n_iterations=10):
+    op_func = eval(f"torch.ops.{op}")
+    args, kwargs = deserialize_args(inps)
+    initial_output = op_func(*args, **kwargs)
+    for _ in range(n_iterations):
+        args, kwargs = deserialize_args(inps)
+        output = op_func(*args, **kwargs)
+        if not torch.allclose(initial_output, output, atol=1e-2, rtol=1e-2):
+            return False
+    return True

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -7,6 +7,7 @@ from BackendBench.utils import (
     deserialize_args,
     _deserialize_tensor,
     uses_cuda_stream,
+    check_for_stable_output,
 )
 
 # Check if CUDA is available
@@ -529,6 +530,26 @@ class TestDeserializeTensor:
             tensor = _deserialize_tensor([10], dtype)
             assert tensor.dtype == dtype
             assert tensor.shape == (10,)
+
+
+class TestCheckForStableOutput:
+    """Test cases for check_for_stable_output function"""
+
+    def test_stable_zeros_op(self):
+        """Test that zeros creation is stable"""
+        op = "aten.zeros"
+        inps = "(([3, 4],), {{'dtype': torch.float32, 'device': 'cuda'}})"
+
+        result = check_for_stable_output(op, inps, n_iterations=5)
+        assert result
+
+    def test_unstable_random_op(self):
+        """Test that random operations are correctly detected as unstable"""
+        op = "aten.randn"
+        inps = "(([3, 3],), {{'dtype': torch.float32, 'device': 'cuda'}})"
+
+        result = check_for_stable_output(op, inps, n_iterations=5)
+        assert not result
 
 
 if __name__ == "__main__":

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -538,7 +538,7 @@ class TestCheckForStableOutput:
     def test_stable_zeros_op(self):
         """Test that zeros creation is stable"""
         op = "aten.zeros"
-        inps = "(([3, 4],), {{'dtype': torch.float32, 'device': 'cuda'}})"
+        inps = "(([3, 4],), {'dtype': torch.float32})"
 
         result = check_for_stable_output(op, inps, n_iterations=5)
         assert result
@@ -546,7 +546,7 @@ class TestCheckForStableOutput:
     def test_unstable_random_op(self):
         """Test that random operations are correctly detected as unstable"""
         op = "aten.randn"
-        inps = "(([3, 3],), {{'dtype': torch.float32, 'device': 'cuda'}})"
+        inps = "(([3, 3],), {'dtype': torch.float32})"
 
         result = check_for_stable_output(op, inps, n_iterations=5)
         assert not result


### PR DESCRIPTION
Fixes: https://github.com/meta-pytorch/BackendBench/issues/71 and https://github.com/meta-pytorch/BackendBench/issues/70

For checking for ones and zeros and noting that in the dataset, I think there should be a followup PR to https://github.com/meta-pytorch/BackendBench/pull/57

