### PR TITLE
Add unit test for waterfalling errors

### DIFF
--- a/test/test_adverse_cases.py
+++ b/test/test_adverse_cases.py
@@ -22,6 +22,7 @@ class TestAdaptiveAvgPool2dBackward:
             None,
         )
 
+        # run test that should brick the gpu due to an illegal memory access
         backend = backends.AtenBackend()
         with pytest.raises(RuntimeError):
             _, _ = eval_one_op(
@@ -31,11 +32,11 @@ class TestAdaptiveAvgPool2dBackward:
                 list(op_test_should_error.performance_tests),
             )
 
-        # add these in case code changes in eval_one_op
+        # add these in case code changes in eval_one_op. There shouldn't be any errors here
         torch.cuda.synchronize()
         torch.cuda.empty_cache()
 
-        # tests that a simple op works afterwards
+        # tests that a simple op works afterwards to make sure we recover after an illegal memory access
         correctness, _ = eval_one_op(
             op_test_should_succeed.op,
             backend[op_test_should_succeed.op],


### PR DESCRIPTION
This pr adds the unit test for https://github.com/meta-pytorch/BackendBench/issues/45

Running this test at the moment (remove the skip decorator before running) should get you something like 

```
sahanp@devgpu011 ~/r/BackendBench (main) [1]> python -m pytest test/test_adverse_cases.py                                                              (pytorch-whl) 
======================================================================== test session starts ========================================================================
platform linux -- Python 3.13.5, pytest-8.4.1, pluggy-1.6.0 -- /home/sahanp/.conda/envs/pytorch-whl/bin/python
cachedir: .pytest_cache
rootdir: /home/sahanp/repos/BackendBench
configfile: pytest.ini
plugins: anyio-4.9.0
collected 1 item                                                                                                                                                    

test/test_adverse_cases.py::TestAdaptiveAvgPool2dBackward::test_adaptive_avg_pool2d_backward_gpu FAILED                                                       [100%]

============================================================================= FAILURES ==============================================================================
________________________________________________ TestAdaptiveAvgPool2dBackward.test_adaptive_avg_pool2d_backward_gpu ________________________________________________
test/test_adverse_cases.py:35: in test_adaptive_avg_pool2d_backward_gpu
    torch.cuda.synchronize()
../../.conda/envs/pytorch-whl/lib/python3.13/site-packages/torch/cuda/__init__.py:1040: in synchronize
    return torch._C._cuda_synchronize()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   RuntimeError: CUDA error: an illegal memory access was encountered
E   CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
E   For debugging consider passing CUDA_LAUNCH_BLOCKING=1
E   Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.
```

You may need to massage the sizes if you are not getting an illegal memory access error.