### PR TITLE
Add precommit hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ CLAUDE.md
 venv/
 ops/
 uv.lock
+
+# Pre-commit
+.pre-commit-cache/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.1
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dev-dependencies = [
     "pytest-mock",
     "pytest-timeout",
     "ruff==0.12.1",
+    "pre-commit",
     "torch",
     "numpy",
     # cupy-cuda12x is platform specific, install manually if needed


### PR DESCRIPTION
This just makes sure we don't have to keep typing 

```
ruff check --fix
ruff format
```

over and over again

Instead

```
pip install pre-commit
pre-commit install
```

And then just make changes