### PR TITLE
Fix eval.py and pyproject.toml

### DIFF
--- a/BackendBench/eval.py
+++ b/BackendBench/eval.py
@@ -61,7 +61,7 @@ def eval_correctness(op, impl, tests):
         if eval_correctness_test(op, impl, test):
             correct += 1
         total += 1
-    return correct / total if total > 0 else 0.0
+    return correct / total
 
 
 def cpu_bench(fn, num_runs=100):

--- a/BackendBench/eval.py
+++ b/BackendBench/eval.py
@@ -61,7 +61,7 @@ def eval_correctness(op, impl, tests):
         if eval_correctness_test(op, impl, test):
             correct += 1
         total += 1
-    return correct / total
+    return correct / total if total > 0 else 0.0
 
 
 def cpu_bench(fn, num_runs=100):
@@ -104,7 +104,7 @@ def eval_one_op(op, impl, correctness_tests, performance_tests):
     # but that should be a separate PR.
     if uses_cuda_stream(impl):
         logger.warning(f"Skipping {op.__name__} because it uses CUDA stream")
-        return 0, 0
+        return 0.0, 1.0
     return eval_correctness(op, impl, correctness_tests), eval_performance(
         op, impl, performance_tests
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "pytest",
     "requests",
     "huggingface_hub",
+    "pandas"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This pr makes three fixes:

- Fix `def eval_one_op(op, impl, correctness_tests, performance_tests)` in `eval.py` to return performance speedup as 1 instead of zero when using CUDA stream.
- Fix `def eval_correctness(op, impl, tests)` in `eval.py` to avoid divide by zero. 
- Add `pandas` to `pyproject.toml` since it's used in torchbench.