### PR TITLE
Filter out operators we cannot test correctness for

### DIFF
--- a/BackendBench/scripts/dataset_filters.py
+++ b/BackendBench/scripts/dataset_filters.py
@@ -20,6 +20,13 @@ SKIP_OPERATORS = [
     "_fft_c2c.default",  # cuFFT only supports dimensions whose sizes are powers of two when computing in half precision
 ]
 
+RANDOM_OPERATORS = [
+    "empty_like",
+    "new_empty",
+    "new_empty_strided",
+    "bernoulli",
+]
+
 
 def apply_skip_ops_filter(ops):
     for op in ops:
@@ -27,6 +34,12 @@ def apply_skip_ops_filter(ops):
             op["included_in_benchmark"] = False
             op["why_excluded"].append("We cannot run this op on backendbench yet")
             op["runnable"] = False
+
+        if any(skip_op in op["op_name"] for skip_op in RANDOM_OPERATORS):
+            op["included_in_benchmark"] = False
+            op["why_excluded"].append(
+                "This op creates a random output, and therefore cannot be tested for correctness"
+            )
 
         if op["is_synthetic"]:
             op["included_in_benchmark"] = False

--- a/BackendBench/scripts/dataset_filters.py
+++ b/BackendBench/scripts/dataset_filters.py
@@ -20,7 +20,7 @@ SKIP_OPERATORS = [
     "_fft_c2c.default",  # cuFFT only supports dimensions whose sizes are powers of two when computing in half precision
 ]
 
-RANDOM_OPERATORS = [
+UNTESTABLE_OPERATORS = [
     "empty_like",
     "new_empty",
     "new_empty_strided",
@@ -35,10 +35,10 @@ def apply_skip_ops_filter(ops):
             op["why_excluded"].append("We cannot run this op on backendbench yet")
             op["runnable"] = False
 
-        if any(skip_op in op["op_name"] for skip_op in RANDOM_OPERATORS):
+        if any(skip_op in op["op_name"] for skip_op in UNTESTABLE_OPERATORS):
             op["included_in_benchmark"] = False
             op["why_excluded"].append(
-                "This op creates a random output, and therefore cannot be tested for correctness"
+                "This op creates a unpredictable output, and therefore cannot be tested for correctness"
             )
 
         if op["is_synthetic"]:

--- a/BackendBench/scripts/dataset_filters.py
+++ b/BackendBench/scripts/dataset_filters.py
@@ -21,10 +21,10 @@ SKIP_OPERATORS = [
 ]
 
 UNTESTABLE_OPERATORS = [
-    "empty_like",
-    "new_empty",
-    "new_empty_strided",
-    "bernoulli",
+    "empty_like",  # We can check using metadata
+    "new_empty",  # We can check using metadata
+    "new_empty_strided",  # We can check using metadata
+    "bernoulli",  # We can write a custom test to verify this one (albeit not the randomness)
 ]
 
 
@@ -38,7 +38,7 @@ def apply_skip_ops_filter(ops):
         if any(skip_op in op["op_name"] for skip_op in UNTESTABLE_OPERATORS):
             op["included_in_benchmark"] = False
             op["why_excluded"].append(
-                "This op creates a unpredictable output, and therefore cannot be tested for correctness"
+                "BackendBench does not support correctness testing for this op yet"
             )
 
         if op["is_synthetic"]:


### PR DESCRIPTION
The issue this aims to solve is described in https://github.com/meta-pytorch/BackendBench/issues/104

Once this is merged I will update the tritonbench suite.  This PR is a bit specific to tritonbench atm. It is not comprehensive of everything that needs to be accounted for just for what's in the tritonbench test set right now.

### Some analysis
Right now we are using opinfo as our ground truth for testing. However, it has some pretty bogus inputs and outputs (especially with our testing harness in `allclose`. Effectively, for random or fill ops it outputs empty tensors or watermarked inputs. Some examples of this are below.

randint.default
```
[2025-08-22 15:05:16][INFO][eval.py] Looking at randint.default with
[2025-08-22 15:05:16][INFO][eval.py] args - (10, torch.Size([0, 5, 0]))
[2025-08-22 15:05:16][INFO][eval.py] kwargs - {'device': 'cuda'}
[2025-08-22 15:05:16][INFO][eval.py] reference (which is aten) output is: tensor([], device='cuda:0', size=(0, 5, 0), dtype=torch.int64)
[2025-08-22 15:05:16][INFO][eval.py] aten output is: tensor([], device='cuda:0', size=(0, 5, 0), dtype=torch.int64)
``` 
Bernoulli.default
```
[2025-08-22 15:05:16][INFO][eval.py] Looking at bernoulli.default with
[2025-08-22 15:05:16][INFO][eval.py] args - (tensor([], device='cuda:0', size=(0, 3), dtype=torch.bfloat16),)
[2025-08-22 15:05:16][INFO][eval.py] kwargs - {}
[2025-08-22 15:05:16][INFO][eval.py] reference (which is aten) output is: tensor([], device='cuda:0', size=(0, 3), dtype=torch.bfloat16)
[2025-08-22 15:05:16][INFO][eval.py] aten output is: tensor([], device='cuda:0', size=(0, 3), dtype=torch.bfloat16)
```

empty_like.default
```
[2025-08-22 15:05:16][INFO][eval.py] Looking at empty_like.default with
[2025-08-22 15:05:16][INFO][eval.py] args - (tensor(-6.7188, device='cuda:0', dtype=torch.bfloat16),)
[2025-08-22 15:05:16][INFO][eval.py] kwargs - {}
[2025-08-22 15:05:16][INFO][eval.py] reference (which is aten) output is: -6.71875
[2025-08-22 15:05:16][INFO][eval.py] aten output is: -6.71875

[2025-08-22 15:05:16][INFO][eval.py] Looking at empty_like.default with
[2025-08-22 15:05:16][INFO][eval.py] args - (tensor([], device='cuda:0', size=(0, 5, 0), dtype=torch.bfloat16),)
[2025-08-22 15:05:16][INFO][eval.py] kwargs - {}
[2025-08-22 15:05:16][INFO][eval.py] reference (which is aten) output is: tensor([], device='cuda:0', size=(0, 5, 0), dtype=torch.bfloat16)
[2025-08-22 15:05:16][INFO][eval.py] aten output is: tensor([], device='cuda:0', size=(0, 5, 0), dtype=torch.bfloat16)
```

new_empty_strided.default
```
[2025-08-22 15:05:16][INFO][eval.py] Looking at new_empty_strided.default with
[2025-08-22 15:05:16][INFO][eval.py] args - (tensor(-6.7188, device='cuda:0', dtype=torch.bfloat16), (), ())
[2025-08-22 15:05:16][INFO][eval.py] kwargs - {}
[2025-08-22 15:05:16][INFO][eval.py] Error in allclose
[2025-08-22 15:05:16][INFO][eval.py] 
Exception raised for None:
    args: ((T([], bf16), T([], bf16),), {})
    exc: Scalars are not close!

Expected 0.0 but got -6.71875.
Absolute difference: 6.71875 (up to 0.01 allowed)
Relative difference: inf (up to 0.01 allowed)

[2025-08-22 15:05:16][INFO][eval.py] reference (which is aten) output is: -6.71875
[2025-08-22 15:05:16][INFO][eval.py] aten output is: 0.0
[2025-08-22 15:05:16][INFO][eval.py] for new_empty_strided.default is_correct=False abs_error=6.71875 rel_error=1.0
```

This pr allows us to skip these tests for the torchbench as our `allclose` does not handle them.

### What to do later
For pytorch the testing of distributions and random ops can be found at 
[test_distributions.py](https://github.com/pytorch/pytorch/blob/4c36c8a99463c898190a462300ba7f05b5b3384e/test/distributions/test_distributions.py) and [test_random](https://github.com/pytorch/pytorch/blob/c8bb0e4720ddddf3cd1b0b48b336978f763c71ca/test/torch_np/test_random.py)

For fill / tensor creation ops [test_tensor_creation_ops.py](https://github.com/pytorch/pytorch/blob/main/test/test_tensor_creation_ops.py) is where we find those tests

We need to add this testing to backendbench