### PR TITLE
Fix OpInfo correctness tests not being accessible due to generator exhaustion

### DIFF
--- a/BackendBench/eval.py
+++ b/BackendBench/eval.py
@@ -61,6 +61,12 @@ def eval_correctness(op, impl, tests):
         if eval_correctness_test(op, impl, test):
             correct += 1
         total += 1
+
+    # Handle the case where no tests are available
+    if total == 0:
+        logger.warning(f"No correctness tests available for {str(op)}")
+        return 0.0
+
     return correct / total
 
 

--- a/BackendBench/suite/opinfo.py
+++ b/BackendBench/suite/opinfo.py
@@ -84,9 +84,7 @@ def build_op_tests(device, dtype, filter=None):
 
         for overload, indices in op_indices.items():
             if len(indices) > 0:
-                op_info_op_tests.append(
-                    OpInfoOpTest(overload, op.sample_inputs(device, dtype), indices)
-                )
+                op_info_op_tests.append(OpInfoOpTest(overload, sample_inputs, indices))
 
     return op_info_op_tests
 


### PR DESCRIPTION
was trying to run some LLM evals:

```uv run python BackendBench/scripts/main.py --suite opinfo --backend llm-relay --ops "bmm,add" --llm-max-attempts 5 --llm-relay-model gcp-claude-4-sonnet --log-level INFO```

before the change:

No correctness tests available for add.Tensor
No correctness tests available for bmm.default


=== aten.add.Tensor ===
indices: {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
_correctness_tests length: 11
accessible correctness_tests: 0

=== aten.bmm.default ===
indices: {0}
_correctness_tests length: 1
accessible correctness_tests: 0


after the change:

=== aten.add.Tensor ===
indices: {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
_correctness_tests length: 11
accessible correctness_tests: 11

=== aten.bmm.default ===
indices: {0}
_correctness_tests length: 1
accessible correctness_tests: 1
