### PR TITLE
Delete .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-# Global code owners - these users will be automatically requested for review on all PRs
-* @msaroufim @PaliC @jiannanWang


### PR DESCRIPTION
I think this was a bad idea, it was mostly there to give us notifications but everyone is reviewing code fast now so we don't need it