### PR TITLE
Add Ruff import sorting

### DIFF
--- a/.github/scripts/check_license_headers.py
+++ b/.github/scripts/check_license_headers.py
@@ -6,8 +6,8 @@
 
 #!/usr/bin/env python3
 
-import sys
 import argparse
+import sys
 
 REQUIRED_LICENSE_TEXT = "Copyright (c) Meta Platforms, Inc. and affiliates."
 

--- a/BackendBench/backends/llm_relay.py
+++ b/BackendBench/backends/llm_relay.py
@@ -9,9 +9,10 @@ import importlib.util
 import logging
 import os
 import sys
-import torch
 import traceback
 from typing import Callable, Dict, List
+
+import torch
 
 from .base import Backend
 

--- a/BackendBench/data_loaders.py
+++ b/BackendBench/data_loaders.py
@@ -16,11 +16,11 @@ from pathlib import Path
 from typing import Dict, List, Optional, Union
 
 import pyarrow.parquet as pq
-
 import requests
 import torch
-from BackendBench.utils import cleanup_memory_and_gpu, deserialize_args
 from tqdm import tqdm
+
+from BackendBench.utils import cleanup_memory_and_gpu, deserialize_args
 
 
 def _args_size(args):

--- a/BackendBench/eval.py
+++ b/BackendBench/eval.py
@@ -12,7 +12,6 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import torch
 
-
 try:
     if torch.cuda.is_available():
         import triton.testing
@@ -23,7 +22,7 @@ try:
 except ImportError:
     TRITON_AVAILABLE = False
 
-from BackendBench.utils import serialize_args, uses_cuda_stream, compute_errors
+from BackendBench.utils import compute_errors, serialize_args, uses_cuda_stream
 
 logger = logging.getLogger(__name__)
 

--- a/BackendBench/kernel_templates.py
+++ b/BackendBench/kernel_templates.py
@@ -9,11 +9,12 @@ Kernel code templates and prompt engineering for LLM-based kernel generation.
 """
 
 from typing import Dict
+
 from .prompts import (
-    TRITON_KERNEL_PROMPT,
     PYTORCH_KERNEL_PROMPT,
-    TRITON_OPTIMIZATIONS,
     TRITON_EXAMPLE_TEMPLATES,
+    TRITON_KERNEL_PROMPT,
+    TRITON_OPTIMIZATIONS,
 )
 
 

--- a/BackendBench/llm_client.py
+++ b/BackendBench/llm_client.py
@@ -5,7 +5,8 @@
 # LICENSE file in the root directory of this source tree.
 
 import os
-from typing import Dict, Optional, Callable
+from typing import Callable, Dict, Optional
+
 import anthropic
 import requests
 

--- a/BackendBench/multiprocessing_eval.py
+++ b/BackendBench/multiprocessing_eval.py
@@ -18,17 +18,17 @@
 #     results = evaluator.get_results()
 
 import logging
-from dataclasses import dataclass
 import multiprocessing as mp
-import time
 import queue
+import time
 import traceback
+from dataclasses import dataclass
 from typing import Any, List, Optional
 
 import torch
 
 from BackendBench.eval import eval_one_op
-from BackendBench.opregistry import get_operator, _extract_spec_name_from_op
+from BackendBench.opregistry import _extract_spec_name_from_op, get_operator
 
 logger = logging.getLogger(__name__)
 
@@ -64,8 +64,8 @@ class ProcessDeathSignal:
 
 
 def is_pickleable(obj):
-    import pickle
     import io
+    import pickle
 
     try:
         with io.BytesIO() as stream:

--- a/BackendBench/scripts/create_simple_test_ops.py
+++ b/BackendBench/scripts/create_simple_test_ops.py
@@ -11,8 +11,8 @@ Create simple kernel implementations for 5 common operations.
 Each just calls the original PyTorch function.
 """
 
-import os
 import logging
+import os
 
 logger = logging.getLogger(__name__)
 

--- a/BackendBench/scripts/create_watermarked_operators.py
+++ b/BackendBench/scripts/create_watermarked_operators.py
@@ -11,11 +11,10 @@ Create watermarked operator implementations that return constant tensors.
 These implementations will verify monkey patching works but will fail correctness tests.
 """
 
-import os
 import argparse
 import hashlib
+import os
 from pathlib import Path
-
 
 WATERMARK_BASE = 42.0
 

--- a/BackendBench/scripts/debug_operator_mapping.py
+++ b/BackendBench/scripts/debug_operator_mapping.py
@@ -20,6 +20,7 @@ Output:
 
 import csv
 from pathlib import Path
+
 from BackendBench.backends.directory import DirectoryBackend
 
 

--- a/BackendBench/scripts/generate_operator_coverage_csv.py
+++ b/BackendBench/scripts/generate_operator_coverage_csv.py
@@ -9,13 +9,14 @@
 """Generate comprehensive operator coverage CSV for BackendBench"""
 
 import csv
-import torch
 
+import torch
 from torch.testing._internal.common_methods_invocations import op_db
+
 from BackendBench.scripts.pytorch_operators import (
-    get_pytorch_operators,
     extract_aten_ops,
     extract_operator_name,
+    get_pytorch_operators,
 )
 from BackendBench.suite import OpInfoTestSuite, TorchBenchTestSuite
 

--- a/BackendBench/scripts/get_big_inputs.py
+++ b/BackendBench/scripts/get_big_inputs.py
@@ -14,6 +14,8 @@ from typing import Dict, List, Tuple
 
 import requests
 import torch
+from main import setup_logging
+from tqdm import tqdm
 
 from BackendBench.torchbench_suite import (
     _args_size,
@@ -23,8 +25,6 @@ from BackendBench.torchbench_suite import (
     dtype_abbrs,
     SKIP_OPERATORS,
 )
-from main import setup_logging
-from tqdm import tqdm
 from BackendBench.utils import cleanup_memory_and_gpu
 
 # Magic numbers and constants

--- a/BackendBench/scripts/get_tests_stat.py
+++ b/BackendBench/scripts/get_tests_stat.py
@@ -11,8 +11,9 @@ This is a helper script to analyze the test suite and provide statistics about t
 import statistics
 
 import torch
-from BackendBench.suite import OpInfoTestSuite, TorchBenchTestSuite, FactoTestSuite
+
 from BackendBench.scripts.pytorch_operators import extract_operator_name
+from BackendBench.suite import FactoTestSuite, OpInfoTestSuite, TorchBenchTestSuite
 
 
 def analyze_test_suite(suite):

--- a/BackendBench/scripts/main.py
+++ b/BackendBench/scripts/main.py
@@ -9,19 +9,19 @@ import os
 import sys
 from typing import Dict
 
-import BackendBench.backends as backends
-import BackendBench.eval as eval
-import BackendBench.multiprocessing_eval as multiprocessing_eval
 import click
 import torch
 
+import BackendBench.backends as backends
+import BackendBench.eval as eval
+import BackendBench.multiprocessing_eval as multiprocessing_eval
 from BackendBench.llm_client import ClaudeKernelGenerator, LLMKernelGenerator
 from BackendBench.suite import (
-    SmokeTestSuite,
-    OpInfoTestSuite,
     DEFAULT_HUGGINGFACE_URL,
-    TorchBenchTestSuite,
     FactoTestSuite,
+    OpInfoTestSuite,
+    SmokeTestSuite,
+    TorchBenchTestSuite,
 )
 
 logger = logging.getLogger(__name__)

--- a/BackendBench/scripts/parquet_trace_converter.py
+++ b/BackendBench/scripts/parquet_trace_converter.py
@@ -15,11 +15,11 @@ from typing import List
 import click
 import pyarrow as pa
 import pyarrow.parquet as pq
+from huggingface_hub import HfApi
+
 from BackendBench.data_loaders import _load_from_trace
 from BackendBench.scripts.dataset_filters import apply_skip_ops_filter
 from BackendBench.torchbench_suite import DEFAULT_HUGGINGFACE_URL
-from huggingface_hub import HfApi
-
 
 """
 Columns for the parquet dataset:

--- a/BackendBench/scripts/pytorch_operators.py
+++ b/BackendBench/scripts/pytorch_operators.py
@@ -9,8 +9,9 @@
 """PyTorch operator utilities for BackendBench analysis"""
 
 import urllib.request
-import yaml
 from typing import List
+
+import yaml
 
 
 def extract_operator_name(op_str: str) -> str:

--- a/BackendBench/scripts/setup_operator_directories.py
+++ b/BackendBench/scripts/setup_operator_directories.py
@@ -11,9 +11,9 @@ Setup script to create directory structure for all PyTorch operators.
 This creates empty directories that LLM researchers can fill with generated kernels.
 """
 
-import os
-import csv
 import argparse
+import csv
+import os
 from pathlib import Path
 
 # Import the generate_coverage_csv functionality

--- a/BackendBench/suite/__init__.py
+++ b/BackendBench/suite/__init__.py
@@ -13,11 +13,11 @@ collection of tests to evaluate the correctness and/or performacne of
 backend implementations by comparing them against PyTorch operations.
 """
 
-from .base import Test, OpTest, TestSuite
+from .base import OpTest, Test, TestSuite
 from .facto import FactoTestSuite
 from .opinfo import OpInfoTestSuite
-from .smoke import SmokeTestSuite, randn
-from .torchbench import TorchBenchOpTest, TorchBenchTestSuite, DEFAULT_HUGGINGFACE_URL
+from .smoke import randn, SmokeTestSuite
+from .torchbench import DEFAULT_HUGGINGFACE_URL, TorchBenchOpTest, TorchBenchTestSuite
 
 __all__ = [
     "Test",

--- a/BackendBench/suite/facto.py
+++ b/BackendBench/suite/facto.py
@@ -22,6 +22,7 @@ except ImportError:
 
 from BackendBench.eval import allclose
 from BackendBench.opregistry import get_operator
+
 from .base import OpTest, TestSuite
 
 logger = logging.getLogger(__name__)

--- a/BackendBench/suite/opinfo.py
+++ b/BackendBench/suite/opinfo.py
@@ -11,6 +11,7 @@ from torch.testing._internal.common_methods_invocations import op_db
 from torch.utils._python_dispatch import TorchDispatchMode
 
 from BackendBench.eval import allclose
+
 from .base import OpTest, TestSuite
 
 logger = logging.getLogger(__name__)

--- a/BackendBench/suite/smoke.py
+++ b/BackendBench/suite/smoke.py
@@ -7,7 +7,8 @@
 import torch
 
 from BackendBench.opregistry import get_operator
-from .base import Test, OpTest, TestSuite
+
+from .base import OpTest, Test, TestSuite
 
 
 def randn(*args, **kwargs):

--- a/BackendBench/suite/torchbench.py
+++ b/BackendBench/suite/torchbench.py
@@ -9,6 +9,7 @@ Load aten inputs from serialized txt files and parquet files.
 """
 
 import torch  # noqa: F401
+
 from BackendBench.data_loaders import (
     _args_size,
     load_ops_from_source,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,4 +59,11 @@ dev-dependencies = [
 [tool.ruff]
 line-length = 100
 
-[tool.ruff.format]
+[tool.ruff.lint]
+extend-select = ["I"]  # Enable isort rules
+
+[tool.ruff.lint.isort]
+case-sensitive = false
+combine-as-imports = true
+detect-same-package = false
+order-by-type = false

--- a/test/test_adverse_cases.py
+++ b/test/test_adverse_cases.py
@@ -5,10 +5,11 @@
 # LICENSE file in the root directory of this source tree.
 
 import pytest
-from BackendBench.suite import TorchBenchOpTest
-import BackendBench.multiprocessing_eval as multiprocessing_eval
-import BackendBench.backends as backends
 import torch
+
+import BackendBench.backends as backends
+import BackendBench.multiprocessing_eval as multiprocessing_eval
+from BackendBench.suite import TorchBenchOpTest
 
 
 class TestAdaptiveAvgPool2dBackward:

--- a/test/test_backend_evaluation.py
+++ b/test/test_backend_evaluation.py
@@ -16,9 +16,9 @@ Tests:
 4. eval.py integration works properly
 """
 
+import subprocess
 import sys
 import unittest
-import subprocess
 from pathlib import Path
 
 import torch

--- a/test/test_backends.py
+++ b/test/test_backends.py
@@ -6,6 +6,7 @@
 
 import pytest
 import torch
+
 from BackendBench.backends import (
     AtenBackend,
     FlagGemsBackend,

--- a/test/test_directory_backend.py
+++ b/test/test_directory_backend.py
@@ -15,6 +15,7 @@ sys.path.insert(0, ".")
 
 import pytest
 import torch
+
 from BackendBench.backends import DirectoryBackend
 
 

--- a/test/test_eval.py
+++ b/test/test_eval.py
@@ -9,13 +9,14 @@ import torch
 
 try:
     import importlib.util
+
     from BackendBench.eval import (
-        format_exception,
         allclose,
-        eval_correctness_test,
-        eval_correctness,
-        eval_one_op,
         cpu_bench,
+        eval_correctness,
+        eval_correctness_test,
+        eval_one_op,
+        format_exception,
         gpu_bench,
     )
 

--- a/test/test_facto_suite.py
+++ b/test/test_facto_suite.py
@@ -4,14 +4,14 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 
+import importlib.util
+
 import pytest
 import torch
 
 import BackendBench.backends as backends
 from BackendBench.eval import eval_one_op
 from BackendBench.suite import FactoTestSuite
-
-import importlib.util
 
 HAS_FACTO_DEPS = importlib.util.find_spec("facto") is not None
 

--- a/test/test_smoke.py
+++ b/test/test_smoke.py
@@ -9,9 +9,10 @@ import torch
 
 try:
     import importlib.util
-    from BackendBench.suite import SmokeTestSuite
-    from BackendBench.eval import eval_one_op
+
     import BackendBench.backends as backends
+    from BackendBench.eval import eval_one_op
+    from BackendBench.suite import SmokeTestSuite
 
     HAS_TRITON = importlib.util.find_spec("triton") is not None
 except ImportError:

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -6,8 +6,9 @@
 
 import pytest
 import torch
-from BackendBench.suite import randn, Test, OpTest, TestSuite, SmokeTestSuite
+
 from BackendBench.opregistry import get_operator
+from BackendBench.suite import OpTest, randn, SmokeTestSuite, Test, TestSuite
 
 
 class TestRandnFunction:

--- a/test/test_torchbench_suite.py
+++ b/test/test_torchbench_suite.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
+
 from BackendBench.suite import TorchBenchOpTest
 
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -4,16 +4,17 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 
-import torch
 import math
+
 import pytest
+import torch
 
 from BackendBench.utils import (
-    serialize_args,
-    deserialize_args,
     _deserialize_tensor,
-    uses_cuda_stream,
     compute_errors,
+    deserialize_args,
+    serialize_args,
+    uses_cuda_stream,
 )
 
 # Check if CUDA is available


### PR DESCRIPTION
This PR adds a new Ruff rule to enable import sorting. The rule is added to `pyproject.toml`, and all other changes are generated by Ruff.

Since this update affects a large number of files, we may want to choose an appropriate time to merge it to minimize potential merge conflicts.