### PR TITLE
Update README product pitch

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 BackendBench is an evaluation suite for testing how well LLMs and humans can write PyTorch backends. It lets developers add custom kernels in an organized directory structure and dynamically override PyTorch's core operators at runtime—resulting in a fully functional PyTorch backend you can pip install and use with existing models, no changes required.
 
 Features:
-1. Comprehensive correctness testing via PyTorch's OpInfo test suite
+1. Comprehensive correctness testing via PyTorch's OpInfo and FACTO test suites
 2. Performance benchmarks using real tensor shapes from popular Hugging Face models
 3. Clean path to upstream your kernels to PyTorch (if it passes our tests, it's likely correct enough to merge)
 

--- a/README.md
+++ b/README.md
@@ -9,43 +9,10 @@ Features:
 
 Why it matters: Many kernel optimization efforts struggle with correctness. Our approach ensures your kernels are production-ready by meeting PyTorch's own standards.
 
-# Installation:
+## Installation:
 
-Install using uv (recommended):
 ```bash
-uv add backendbench
-```
-
-Or install in development mode:
-```bash
-uv sync --dev
-```
-
-# Usage:
-
-Run a simple smoke test (relu) with the default ATen backend:
-```bash
-uv run python BackendBench/scripts/main.py --suite smoke --backend aten
-```
-
-Run the smoke test with FlagGems:
-```bash
-uv run python BackendBench/scripts/main.py --suite smoke --backend flag_gems
-```
-
-Run opinfo tests (correctness only) with ATen
-```bash
-uv run python BackendBench/scripts/main.py --suite opinfo --backend aten
-```
-
-Run a filtered set of opinfo tests with FlagGems
-```bash
-uv run python BackendBench/scripts/main.py --suite opinfo --backend flag_gems --ops "add,sub"
-```
-
-Run all the opinfo tests with FlagGems (takes a few minutes)
-```bash
-uv run python BackendBench/scripts/main.py --suite opinfo --backend flag_gems
+pip install .
 ```
 
 ## LLM-Based Kernel Generation and Evaluation
@@ -56,127 +23,6 @@ Run LLM evaluation on smoke test (relu operation):
 ```bash
 export ANTHROPIC_API_KEY=your_api_key_here
 uv run python BackendBench/scripts/main.py --suite smoke --backend llm
-```
-
-## KernelAgent-Based Triton Kernel Generation
-
-Generate and evaluate PyTorch kernels using KernelAgent's advanced system with parallel workers and iterative refinement:
-
-**Prerequisites**: Initialize the KernelAgent submodule:
-```bash
-git submodule update --init --recursive
-```
-
-Run KernelAgent evaluation on smoke test (relu operation):
-```bash
-export OPENAI_API_KEY=your_api_key_here
-uv run python BackendBench/scripts/main.py --suite smoke --backend kernel_agent
-```
-
-Run KernelAgent with custom configuration:
-```bash
-export OPENAI_API_KEY=your_api_key_here
-uv run python BackendBench/scripts/main.py --suite smoke --backend kernel_agent --kernel-agent-workers 6 --kernel-agent-max-rounds 15
-```
-
-Run KernelAgent on opinfo tests with a specific operation:
-```bash
-export OPENAI_API_KEY=<your_api_key_here>
-uv run python BackendBench/scripts/main.py --suite opinfo --backend kernel_agent --ops "add"
-```
-
-## Directory-Based Kernel Development
-
-BackendBench supports a simple directory structure for manually adding kernel implementations. This is perfect for researchers who want to contribute optimized kernels without dealing with complex generation systems.
-
-### Directory Structure
-
-Create kernels in the following structure:
-```
-generated_kernels/
-├── relu/
-│   └── relu_implementation_1.py
-├── add/  
-│   └── add_implementation_1.py
-├── mul/
-│   └── mul_implementation_1.py
-└── ...
-```
-
-### How to Add Your Kernels
-
-1. **Create the operation directory:**
-   ```bash
-   mkdir generated_kernels/{op_name}
-   ```
-
-2. **Create your implementation file:**
-   ```bash
-   # Example: generated_kernels/relu/relu_implementation_1.py
-   ```
-
-3. **Write your kernel following this template:**
-   ```python
-   import torch
-   
-   def {op_name}_kernel_impl(*args, **kwargs):
-       """
-       Your kernel implementation.
-       Must match the PyTorch operation signature exactly.
-       """
-       # Your implementation here
-       return result
-   
-   # Optional: Add a test
-   if __name__ == "__main__":
-       pass
-   ```
-
-### Operation Name Mapping
-
-Use these exact directory names for common operations:
-- `relu` → `torch.ops.aten.relu.default`  
-- `add` → `torch.ops.aten.add.Tensor`
-- `mul` → `torch.ops.aten.mul.Tensor` 
-- `div` → `torch.ops.aten.div.Tensor`
-
-To find the correct name for other operations:
-```python
-# Find operation name
-import torch
-op = torch.ops.aten.some_op.some_variant
-print(str(op).split('aten.')[-1].split('.')[0])  # Use this as directory name
-```
-
-### Example Implementation
-
-Here's a complete example for ReLU:
-
-```python
-# generated_kernels/relu/relu_implementation_1.py
-import torch
-
-def relu_kernel_impl(input_tensor):
-    return torch.maximum(input_tensor, torch.zeros_like(input_tensor))
-
-if __name__ == "__main__":
-    # Test on CPU
-    x = torch.tensor([-2.0, -1.0, 0.0, 1.0, 2.0])
-    result = relu_kernel_impl(x)
-    expected = torch.tensor([0.0, 0.0, 0.0, 1.0, 2.0])
-    print(f"Test passed: {torch.allclose(result, expected)}")
-```
-
-### Testing Your Kernels
-
-Test individual implementations:
-```bash
-uv run python generated_kernels/relu/relu_implementation_1.py
-```
-
-Test with BackendBench:
-```bash
-uv run python BackendBench/scripts/main.py --suite smoke --backend directory
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
 ## BackendBench
 
-A lot of people are now interested in optimizing existing kernels in PyTorch. This audience includes both systems researchers experimenting with new DSLs and LLM researchers looking to automate kernel authoring completely. But many existing efforts have been plagued by how to ensure correctness.
+BackendBench is an evaluation suite for testing how well LLMs and humans can write PyTorch backends. It lets developers add custom kernels in an organized directory structure and dynamically override PyTorch's core operators at runtime—resulting in a fully functional PyTorch backend you can pip install and use with existing models, no changes required.
 
-Our take is that if a kernel can replace an existing PyTorch operator and be merged into PyTorch's official codebase then it's far more likely to be correct but hacking on PyTorch's kernels has historically been challenging.
+Features:
+1. Comprehensive correctness testing via PyTorch's OpInfo test suite
+2. Performance benchmarks using real tensor shapes from popular Hugging Face models
+3. Clean path to upstream your kernels to PyTorch (if it passes our tests, it's likely correct enough to merge)
 
-BackendBench is an evaluation suite that tests how good LLMs and humans are at writing a full fledged PyTorch backend. We make it possible for developers to add their custom kernels in well organized directory structure and dynamically override the core PyTorch aten operators at runtime. The outcome is a fully functional readable PyTorch backend you can pip install and run real models on with no model changes!
-
-We provide both
-1. Comprehensive operator level correctness checks using the PyTorch OpInfo test suite
-2. Performance checks using the ops that show up in the most popular Hugging Face models with realistic tensor shapes
+Why it matters: Many kernel optimization efforts struggle with correctness. Our approach ensures your kernels are production-ready by meeting PyTorch's own standards.
 
 # Installation:
 


### PR DESCRIPTION
in prep for release, gonna keep sending small PRs like this - core ideas are 
1. simplify the product pitch
2. remove front row mention of testing flags_gems since that's not too relevant
3. remove kernelagent stuff since it's not oss yet, it's still in code for us to easily experiment with but doesnt make sense to be part of the main readme
4. remove the backend directory instructions since I'm updating that now as we speak in another PR

Docs will look more complete after https://github.com/meta-pytorch/BackendBench/pull/124 gets merged

And we add a few plots from @shaahins and @Laurawly 