### PR TITLE
Update torchbench test suite to remove unsqueeze and _cudnn_rnn

### DIFF
--- a/BackendBench/data_loaders.py
+++ b/BackendBench/data_loaders.py
@@ -30,10 +30,6 @@ TORCHBENCH_SUITE_HF_COMMIT = "ca7b1361b162d1499cb22ea4ad589dae506ead5d"
 TORCHBENCH_SUITE_FILE = "backend_bench_problems.parquet"
 
 
-def _get_hf_url():
-    return f"https://huggingface.co/datasets/{HUGGINGFACE_REPO}/resolve/{TORCHBENCH_SUITE_HF_COMMIT}/{TORCHBENCH_SUITE_FILE}"
-
-
 def _args_size(args):
     """Calculate the size of arguments in bytes."""
 

--- a/BackendBench/data_loaders.py
+++ b/BackendBench/data_loaders.py
@@ -18,7 +18,6 @@ import pyarrow.parquet as pq
 
 import requests
 import torch
-from BackendBench.utils import cleanup_memory_and_gpu, deserialize_args
 from datasets import load_dataset
 from tqdm import tqdm
 
@@ -27,7 +26,7 @@ from tqdm import tqdm
 # you can explore the dataset here
 # https://huggingface.co/datasets/GPUMODE/backendbench_tests
 HUGGINGFACE_REPO = "GPUMODE/backendbench_tests"
-TORCHBENCH_SUITE_HF_COMMIT = "25a7c56b0a4029b192b61e32fd403e19258487e1"
+TORCHBENCH_SUITE_HF_COMMIT = "ca7b1361b162d1499cb22ea4ad589dae506ead5d"
 TORCHBENCH_SUITE_FILE = "backend_bench_problems.parquet"
 
 
@@ -80,11 +79,6 @@ def _parse_trace_file(
                 cnt = int(m.group(0).split(",")[0].split(":")[1])
 
                 if filter is None or any(f in op for f in filter):
-                    args, kwargs = deserialize_args(args_str)
-                    size = _args_size(args) + _args_size(list(kwargs.values()))
-                    size = size / (1024 * 1024)  # Convert to MB
-                    del args, kwargs
-                    cleanup_memory_and_gpu()
                     is_synthetic = cnt == 0
 
                     op_inputs.append(
@@ -92,7 +86,6 @@ def _parse_trace_file(
                             "uuid": hashlib.sha256(args_str.encode() + op.encode()).hexdigest(),
                             "op_name": op,
                             "args": args_str,
-                            "arg_size": size,
                             "count": cnt,
                             "is_synthetic": is_synthetic,
                         }
@@ -139,11 +132,6 @@ def _parse_trace_stream(
             cnt = int(m.group(0).split(",")[0].split(":")[1])
 
             if filter is None or any(f in op for f in filter):
-                args, kwargs = deserialize_args(args_str)
-                size = _args_size(args) + _args_size(list(kwargs.values()))
-                del args, kwargs
-                cleanup_memory_and_gpu()
-                size = size / (1024 * 1024)  # Convert to MB
                 is_synthetic = cnt == 0
 
                 op_inputs.append(
@@ -151,7 +139,6 @@ def _parse_trace_stream(
                         "uuid": hashlib.sha256(args_str.encode() + op.encode()).hexdigest(),
                         "op_name": op,
                         "args": args_str,
-                        "arg_size": size,
                         "count": cnt,
                         "is_synthetic": is_synthetic,
                     }

--- a/BackendBench/data_loaders.py
+++ b/BackendBench/data_loaders.py
@@ -30,6 +30,10 @@ TORCHBENCH_SUITE_HF_COMMIT = "ca7b1361b162d1499cb22ea4ad589dae506ead5d"
 TORCHBENCH_SUITE_FILE = "backend_bench_problems.parquet"
 
 
+def _get_hf_url():
+    return f"https://huggingface.co/datasets/{HUGGINGFACE_REPO}/resolve/{TORCHBENCH_SUITE_HF_COMMIT}/{TORCHBENCH_SUITE_FILE}"
+
+
 def _args_size(args):
     """Calculate the size of arguments in bytes."""
 

--- a/BackendBench/eval.py
+++ b/BackendBench/eval.py
@@ -12,12 +12,6 @@ from collections import defaultdict
 from pathlib import Path
 from typing import List, Optional, Tuple, Union
 import math
-from BackendBench.data_loaders import (
-    TORCHBENCH_SUITE_HF_COMMIT,
-    HUGGINGFACE_REPO,
-    TORCHBENCH_SUITE_FILE,
-    _get_hf_url,
-)
 
 import torch
 from BackendBench.utils import compute_errors, serialize_args, uses_cuda_stream
@@ -276,7 +270,6 @@ def save_results(
     geomean_perf: float = None,
     perf_at_p_score: float = None,
     p: float = 1.0,
-    uses_torchbench: bool = False,
 ):
     """Save results without creating per-operator directories.
 
@@ -289,7 +282,6 @@ def save_results(
         geomean_perf: Geometric mean of performance scores
         perf_at_p_score: Performance at threshold p score
         p: The threshold value used for perf@p calculation
-        uses_torchbench: Whether the benchmark uses the TorchBench test suite
 
     Structure created:
         output_path/
@@ -411,7 +403,6 @@ def save_results(
             geomean_perf=geomean_perf,
             perf_at_p_score=perf_at_p_score,
             p=p,
-            uses_torchbench=uses_torchbench,
         )
 
     # Log summary
@@ -425,7 +416,6 @@ def save_readme(
     geomean_perf: float,
     perf_at_p_score: float,
     p: float = 1.0,
-    uses_torchbench: bool = False,
 ):
     """Save a README file with run summary and results.
 
@@ -436,7 +426,6 @@ def save_readme(
         geomean_perf: Geometric mean of performance scores
         perf_at_p_score: Performance at threshold p score
         p: The threshold value used for perf@p calculation
-        uses_torchbench: Whether the benchmark uses the TorchBench test suite
     """
     base_dir = Path(output_path)
     base_dir.mkdir(parents=True, exist_ok=True)
@@ -471,15 +460,6 @@ def save_readme(
         f.write("- `operator_summary.csv`: Operator-level summary statistics\n")
         f.write("- `failed_ops.json`: Log of failed operations (if any)\n")
         f.write("- `README.md`: This file\n")
-
-        if uses_torchbench:
-            f.write("\n\n")
-            f.write("## TorchBench Test Suite Source\n\n")
-            f.write("This run used the TorchBench test suite from the following commit:\n\n")
-            f.write(f"- TorchBench commit: {TORCHBENCH_SUITE_HF_COMMIT}\n")
-            f.write(f"- TorchBench repo: {HUGGINGFACE_REPO}\n")
-            f.write(f"- TorchBench suite file: {TORCHBENCH_SUITE_FILE}\n")
-            f.write(f"You can download the test suite locally from: {_get_hf_url()}")
 
     logger.info(f"README saved to {readme_path}")
 

--- a/BackendBench/eval.py
+++ b/BackendBench/eval.py
@@ -12,6 +12,12 @@ from collections import defaultdict
 from pathlib import Path
 from typing import List, Optional, Tuple, Union
 import math
+from BackendBench.data_loaders import (
+    TORCHBENCH_SUITE_HF_COMMIT,
+    HUGGINGFACE_REPO,
+    TORCHBENCH_SUITE_FILE,
+    _get_hf_url,
+)
 
 import torch
 from BackendBench.utils import compute_errors, serialize_args, uses_cuda_stream
@@ -270,6 +276,7 @@ def save_results(
     geomean_perf: float = None,
     perf_at_p_score: float = None,
     p: float = 1.0,
+    uses_torchbench: bool = False,
 ):
     """Save results without creating per-operator directories.
 
@@ -277,6 +284,12 @@ def save_results(
         correctness_results: List of correctness test results
         performance_results: List of performance test results
         output_path: Base directory for saving results
+        command: Command used to run the benchmark
+        mean_correctness: Mean correctness score
+        geomean_perf: Geometric mean of performance scores
+        perf_at_p_score: Performance at threshold p score
+        p: The threshold value used for perf@p calculation
+        uses_torchbench: Whether the benchmark uses the TorchBench test suite
 
     Structure created:
         output_path/
@@ -398,6 +411,7 @@ def save_results(
             geomean_perf=geomean_perf,
             perf_at_p_score=perf_at_p_score,
             p=p,
+            uses_torchbench=uses_torchbench,
         )
 
     # Log summary
@@ -411,6 +425,7 @@ def save_readme(
     geomean_perf: float,
     perf_at_p_score: float,
     p: float = 1.0,
+    uses_torchbench: bool = False,
 ):
     """Save a README file with run summary and results.
 
@@ -421,6 +436,7 @@ def save_readme(
         geomean_perf: Geometric mean of performance scores
         perf_at_p_score: Performance at threshold p score
         p: The threshold value used for perf@p calculation
+        uses_torchbench: Whether the benchmark uses the TorchBench test suite
     """
     base_dir = Path(output_path)
     base_dir.mkdir(parents=True, exist_ok=True)
@@ -455,6 +471,15 @@ def save_readme(
         f.write("- `operator_summary.csv`: Operator-level summary statistics\n")
         f.write("- `failed_ops.json`: Log of failed operations (if any)\n")
         f.write("- `README.md`: This file\n")
+
+        if uses_torchbench:
+            f.write("\n\n")
+            f.write("## TorchBench Test Suite Source\n\n")
+            f.write("This run used the TorchBench test suite from the following commit:\n\n")
+            f.write(f"- TorchBench commit: {TORCHBENCH_SUITE_HF_COMMIT}\n")
+            f.write(f"- TorchBench repo: {HUGGINGFACE_REPO}\n")
+            f.write(f"- TorchBench suite file: {TORCHBENCH_SUITE_FILE}\n")
+            f.write(f"You can download the test suite locally from: {_get_hf_url()}")
 
     logger.info(f"README saved to {readme_path}")
 

--- a/BackendBench/op_categories.py
+++ b/BackendBench/op_categories.py
@@ -40,4 +40,5 @@ UNSUPPORTED_OPERATORS = [
     "upsample_bilinear2d_backward.vec",
     "_cudnn_rnn_backward.default",  # RuntimeError: cuDNN error: CUDNN_STATUS_BAD_PARAM
     "_fft_c2c.default",  # cuFFT only supports dimensions whose sizes are powers of two when computing in half precision
+    "_cudnn_rnn.default",  # We are running into numerical stability issues with running the forward pass multiple times
 ]

--- a/BackendBench/scripts/dataset_filters.py
+++ b/BackendBench/scripts/dataset_filters.py
@@ -23,18 +23,19 @@ RELATIVE_RUNTIME_THRESHOLD = 1.3
 
 def apply_skip_ops_filter(ops):
     for op in tqdm.tqdm(ops, desc="Filtering ops by skip and synthetic ops"):
-        if any(s in op for s in UNSUPPORTED_OPERATORS):
+        op_name = op["op_name"]
+        if any(s in op_name for s in UNSUPPORTED_OPERATORS):
             op["included_in_benchmark"] = False
             op["why_excluded"].append("We cannot run this op on backendbench yet")
             op["runnable"] = False
 
-        if any(s in op for s in RANDOM_OPS):
+        if any(s in op_name for s in RANDOM_OPS):
             op["included_in_benchmark"] = False
             op["why_excluded"].append(
                 "BackendBench does not support correctness testing for random ops yet"
             )
 
-        if any(s in op for s in TENSOR_CREATION_AND_MANIPULATION_OPS):
+        if any(s in op_name for s in TENSOR_CREATION_AND_MANIPULATION_OPS):
             op["included_in_benchmark"] = False
             op["why_excluded"].append(
                 "BackendBench does not support correctness testing for tensor creation and manipulation ops yet"
@@ -51,7 +52,7 @@ def apply_skip_ops_filter(ops):
 
 def apply_runtime_filter(ops):
     def _overhead_benchmark():
-        return torch.randn(1, device="cuda")
+        return torch.empty(0, device="cuda")
 
     runtime_threshold_ms = do_bench(_overhead_benchmark, warmup=25, rep=100)
 

--- a/BackendBench/scripts/main.py
+++ b/BackendBench/scripts/main.py
@@ -14,7 +14,6 @@ import BackendBench.eval as eval
 import BackendBench.multiprocessing_eval as multiprocessing_eval
 import click
 import torch
-from BackendBench.data_loaders import _get_hf_url
 
 from BackendBench.llm_client import ClaudeKernelGenerator, LLMKernelGenerator
 from BackendBench.suite import (
@@ -307,9 +306,6 @@ def cli(
     print(
         f"perf@p score (rate of correct samples with a speedup greater than p, p={p}): {perf_at_p_score:.2f}"
     )
-    if suite.name == "torchbench":
-        print("**TorchBench Test Suite Source**")
-        print(f"You can download the test suite locally from: {_get_hf_url()}")
 
     command = "python -m BackendBench.scripts.main " + " ".join(sys.argv[1:])
 
@@ -325,7 +321,6 @@ def cli(
             geomean_perf=geomean_perf,
             perf_at_p_score=perf_at_p_score,
             p=p,
-            uses_torchbench=suite.name == "torchbench",
         )
         print(f"Results saved to: {log_dir}")
 

--- a/BackendBench/scripts/main.py
+++ b/BackendBench/scripts/main.py
@@ -14,6 +14,7 @@ import BackendBench.eval as eval
 import BackendBench.multiprocessing_eval as multiprocessing_eval
 import click
 import torch
+from BackendBench.data_loaders import _get_hf_url
 
 from BackendBench.llm_client import ClaudeKernelGenerator, LLMKernelGenerator
 from BackendBench.suite import (
@@ -306,10 +307,14 @@ def cli(
     print(
         f"perf@p score (rate of correct samples with a speedup greater than p, p={p}): {perf_at_p_score:.2f}"
     )
+    if suite.name == "torchbench":
+        print("**TorchBench Test Suite Source**")
+        print(f"You can download the test suite locally from: {_get_hf_url()}")
 
     command = "python -m BackendBench.scripts.main " + " ".join(sys.argv[1:])
 
     # Save results if not disabled
+
     if not disable_output_logs:
         eval.save_results(
             all_correctness_results,
@@ -320,6 +325,7 @@ def cli(
             geomean_perf=geomean_perf,
             perf_at_p_score=perf_at_p_score,
             p=p,
+            uses_torchbench=suite.name == "torchbench",
         )
         print(f"Results saved to: {log_dir}")
 

--- a/BackendBench/scripts/parquet_trace_converter.py
+++ b/BackendBench/scripts/parquet_trace_converter.py
@@ -228,7 +228,7 @@ def _validate_trace_file(trace_file: str, is_input: bool = True) -> str:
 )
 @click.option(
     "--parquet-name",
-    default="backend_bench_problems_new.parquet",
+    default="backend_bench_problems.parquet",
     type=str,
     help="Parquet filename: URL allowed as input in parquet-to-trace mode, local files in datasets/.",
 )

--- a/BackendBench/scripts/parquet_trace_converter.py
+++ b/BackendBench/scripts/parquet_trace_converter.py
@@ -32,7 +32,6 @@ Columns for the parquet dataset:
 - uuid (int) (hash of op + args)
 - op_name (string)
 - args (string)
-- arg_size (float) (in MB)
 - count (int) (number of times this op + set of args was called in real models)
 - is_synthetic (boolean) (did we generate this op or is it from a real model)
 - included_in_benchmark (boolean)
@@ -229,7 +228,7 @@ def _validate_trace_file(trace_file: str, is_input: bool = True) -> str:
 )
 @click.option(
     "--parquet-name",
-    default="backend_bench_problems.parquet",
+    default="backend_bench_problems_new.parquet",
     type=str,
     help="Parquet filename: URL allowed as input in parquet-to-trace mode, local files in datasets/.",
 )

--- a/BackendBench/suite/torchbench.py
+++ b/BackendBench/suite/torchbench.py
@@ -93,10 +93,6 @@ class TorchBenchTestSuite:
         # Convert to dictionary format using utility function
         self.optests = op_list_to_benchmark_dict(ops_list)
 
-        # Deduplicate the strings in self.optests
-        for op in self.optests:
-            self.optests[op] = list(set(self.optests[op]))
-
     def __iter__(self):
         for op, inputs in self.optests.items():
             if any(s in op for s in UNSUPPORTED_OPERATORS):

--- a/BackendBench/suite/torchbench.py
+++ b/BackendBench/suite/torchbench.py
@@ -93,6 +93,10 @@ class TorchBenchTestSuite:
         # Convert to dictionary format using utility function
         self.optests = op_list_to_benchmark_dict(ops_list)
 
+        # Deduplicate the strings in self.optests
+        for op in self.optests:
+            self.optests[op] = list(set(self.optests[op]))
+
     def __iter__(self):
         for op, inputs in self.optests.items():
             if any(s in op for s in UNSUPPORTED_OPERATORS):


### PR DESCRIPTION
This PR addresses the concerns which were found in https://github.com/meta-pytorch/BackendBench/issues/133 by filtering out the `unsqueeze_` and `_cudnn_rnn` ops.

### `unsqueeze_`
For the unsqueeze operator I believe the failures are due to our bad handling of inplace ops (we do not do deep copies) which leads to bugs, futheremore, as it is a tensor manipulation op we have already deemed the op as uninteresting, and therefore, will likely not include it until we can have a better correctness check for it.

### `_cudnn_rnn`
The reason I am removing this op is that I cannot pinpoint exactly what's wrong here. I have observed that this op would nondeterministically error on the torchbench input `"((T([64, 50, 40], f16), [T([3072, 40], f16), T([3072, 768], f16), T([3072], f16), T([3072], f16)], 4, None, T([1, 64, 768], f16), T([1, 64, 768], f16), 2, 768, 0, 1, True, 0.0, True, False, [], None,), {})"`

Two such logs pasting the error are below 
```
  {
    "op_name": "_cudnn_rnn.default",
    "args": "((T([64, 50, 40], f16), [T([3072, 40], f16), T([3072, 768], f16), T([3072], f16), T([3072], f16)], 4, None, T([1, 64, 768], f16), T([1, 64, 768], f16), 2, 768, 0, 1, True, 0.0, True, False, [], None,), {})",
    "is_correct": false,
    "error_msg": null,
    "max_abs_error": 1.0,
    "max_rel_error": 10000000000.0,
    "test_type": "correctness"
  },
  {
    "op_name": "_cudnn_rnn.default",
    "args": "((T([64, 50, 40], f16), [T([3072, 40], f16), T([3072, 768], f16), T([3072], f16), T([3072], f16)], 4, None, T([1, 64, 768], f16), T([1, 64, 768], f16), 2, 768, 0, 1, True, 0.0, True, False, [], None,), {})",
    "speedup": null,
    "benchmark_time_ms": null,
    "reference_time_ms": 0.8245377704105546,
    "error_msg": "\nException raised for _cudnn_rnn.default:\n    args: ((T([64, 50, 40], f16), [T([3072, 40], f16), T([3072, 768], f16), T([3072], f16), T([3072], f16)], 4, None, T([1, 64, 768], f16), T([1, 64, 768], f16), 2, 768, 0, 1, True, 0.0, True, False, [], None,), {})\n    exc: Reference and result tensors are not close: max absolute error 252.0, max relative error 2519999971328.0\n",
    "successfully_ran": false,
    "test_type": "performance"
  },
```

For debugging I tried deepcopying the arguments, and sadly that did not work. Furthermore, outside of backendbench I cannot repro this error as scripts like https://gist.github.com/PaliC/a14c1409074411405cf4133559072548 don't call error out. There may be a bug in how we're doing evals, however, I think we'll need more time to debug it then for the alpha release. Let's remove this op for now.

### Extra things
- I also removed the args_size column from the torchbench test suite, as 1) we are not using it, 2) it makes it take an extra hour to update the parquet and leads to oom errors with synthetic ops, 3) it is not clear how users would use it.
- I updated the pinned torchbench with the new test suite.