### PR TITLE
[BE] Add testing for output saving logic

### DIFF
--- a/.github/scripts/check_license_headers.py
+++ b/.github/scripts/check_license_headers.py
@@ -6,8 +6,8 @@
 
 #!/usr/bin/env python3
 
-import sys
 import argparse
+import sys
 
 REQUIRED_LICENSE_TEXT = "Copyright (c) Meta Platforms, Inc. and affiliates."
 

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ generated_kernels/
 *.csv
 backendbench_output*
 .DS_Store
+*.bak

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     hooks:
       - id: check-license-headers
         name: Check license headers
-        entry: python .github/scripts/check_license_headers.py
+        entry: uv run python .github/scripts/check_license_headers.py
         language: system
         files: \.py$
         pass_filenames: true

--- a/BackendBench/__init__.py
+++ b/BackendBench/__init__.py
@@ -8,10 +8,11 @@
 BackendBench: A PyTorch backend evaluation framework.
 """
 
-import torch
-from typing import Optional, Union
-from pathlib import Path
 import logging
+from pathlib import Path
+from typing import Optional, Union
+
+import torch
 
 # Import the existing DirectoryBackend implementation
 from BackendBench.backends.directory import DirectoryBackend

--- a/BackendBench/backends/directory.py
+++ b/BackendBench/backends/directory.py
@@ -9,10 +9,9 @@ import logging
 import os
 from typing import Callable, Dict
 
-
-from .base import Backend
 from ..scripts.op_map import query
 from ..utils import get_pytorch_op
+from .base import Backend
 
 logger = logging.getLogger(__name__)
 

--- a/BackendBench/backends/llm.py
+++ b/BackendBench/backends/llm.py
@@ -13,6 +13,7 @@ import traceback
 from typing import Callable, Dict, List
 
 import torch
+
 from BackendBench.llm_client import LLMKernelGenerator
 from BackendBench.multiprocessing_eval import MultiprocessingEvaluator
 from BackendBench.utils import extract_operator_name

--- a/BackendBench/data_loaders.py
+++ b/BackendBench/data_loaders.py
@@ -15,12 +15,10 @@ from pathlib import Path
 from typing import Dict, List, Optional, Union
 
 import pyarrow.parquet as pq
-
 import requests
 import torch
 from datasets import load_dataset
 from tqdm import tqdm
-
 
 # constants for downloading the test set from huggingface
 # you can explore the dataset here

--- a/BackendBench/data_loaders.py
+++ b/BackendBench/data_loaders.py
@@ -17,8 +17,9 @@ from typing import Dict, List, Optional, Union
 import pyarrow.parquet as pq
 import requests
 import torch
-from datasets import load_dataset
 from tqdm import tqdm
+
+from datasets import load_dataset
 
 # constants for downloading the test set from huggingface
 # you can explore the dataset here

--- a/BackendBench/eval.py
+++ b/BackendBench/eval.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from typing import List, Tuple
 
 import torch
+
 from BackendBench.utils import compute_errors, serialize_args, uses_cuda_stream
 
 

--- a/BackendBench/kernel_templates.py
+++ b/BackendBench/kernel_templates.py
@@ -9,11 +9,12 @@ Kernel code templates and prompt engineering for LLM-based kernel generation.
 """
 
 from typing import Dict
+
 from .prompts import (
-    TRITON_KERNEL_PROMPT,
     PYTORCH_KERNEL_PROMPT,
-    TRITON_OPTIMIZATIONS,
     TRITON_EXAMPLE_TEMPLATES,
+    TRITON_KERNEL_PROMPT,
+    TRITON_OPTIMIZATIONS,
 )
 
 

--- a/BackendBench/llm_client.py
+++ b/BackendBench/llm_client.py
@@ -4,14 +4,15 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import Dict, Optional, Callable
+import os
+from typing import Callable, Dict, Optional
+
+import anthropic
 import requests
 from tenacity import retry
 from tenacity.wait import wait_random_exponential
 
 from .kernel_templates import KernelTemplateManager
-import anthropic
-import os
 
 
 class LLMKernelGenerator:

--- a/BackendBench/output.py
+++ b/BackendBench/output.py
@@ -19,38 +19,15 @@ from .eval import CorrectnessTestResult, PerformanceTestResult
 logger = logging.getLogger(__name__)
 
 
-def save_results(
+def _prepare_results_data(
     correctness_results: List[CorrectnessTestResult],
     performance_results: List[PerformanceTestResult],
-    output_path: Union[str, Path] = "backendbench_output",
-    command: str = None,
-    mean_correctness: float = None,
-    geomean_perf: float = None,
-    perf_at_p_score: float = None,
-    p: float = 1.0,
-):
-    """Save results without creating per-operator directories.
+) -> Tuple[List[dict], List[dict], dict]:
+    """Prepare and process results data without file I/O.
 
-    Args:
-        correctness_results: List of correctness test results
-        performance_results: List of performance test results
-        output_path: Base directory for saving results
-        command: Command used to run the benchmark
-        mean_correctness: Mean correctness score
-        geomean_perf: Geometric mean of performance scores
-        perf_at_p_score: Performance at threshold p score
-        p: The threshold value used for perf@p calculation
-
-    Structure created:
-        output_path/
-        ├── OVERALL_SUMMARY.md         # Top level summary of results
-        ├── full_results.json          # Complete results log
-        ├── operator_summary.csv       # Operator-level summary
-        └── failed_ops.json            # Log of failed operations
+    Returns:
+        Tuple of (all_results, failed_tests, op_summaries)
     """
-    base_dir = Path(output_path)
-    base_dir.mkdir(parents=True, exist_ok=True)
-
     # Prep work: save all results as a list of dicts
     all_results = [asdict(result) for result in correctness_results] + [
         asdict(result) for result in performance_results
@@ -59,16 +36,7 @@ def save_results(
     # sort by op_name, then args
     all_results.sort(key=lambda x: (x["op_name"], x["args"]))
 
-    # 1. Save the full log in the base directory
-    full_log_path = base_dir / "full_results.json"
-    failed_ops_path = base_dir / "failed_ops.json"
-    summary_csv_path = base_dir / "operator_summary.csv"
-
-    with open(full_log_path, "w") as f:
-        json.dump(all_results, f, indent=2)
-    logger.info(f"Full results saved to {full_log_path}")
-
-    # 2. Organize results by operator for csv
+    # Organize results by operator for csv
     op_all_results = defaultdict(list)
     op_summaries = {}
 
@@ -123,7 +91,63 @@ def save_results(
             "max_relative_error": max_rel_error,
         }
 
-    # 3. Create operator-level summary CSV
+    # Prepare failed operations log
+    failed_tests = [asdict(result) for result in correctness_results if not result.is_correct] + [
+        asdict(result) for result in performance_results if not result.successfully_ran
+    ]
+    # sort failed_tests
+    failed_tests.sort(key=lambda x: (x["op_name"], x["args"]))
+
+    return all_results, failed_tests, op_summaries
+
+
+def save_results(
+    correctness_results: List[CorrectnessTestResult],
+    performance_results: List[PerformanceTestResult],
+    output_path: Union[str, Path] = "backendbench_output",
+    command: str = None,
+    mean_correctness: float = None,
+    geomean_perf: float = None,
+    perf_at_p_score: float = None,
+    p: float = 1.0,
+):
+    """Save results without creating per-operator directories.
+
+    Args:
+        correctness_results: List of correctness test results
+        performance_results: List of performance test results
+        output_path: Base directory for saving results
+        command: Command used to run the benchmark
+        mean_correctness: Mean correctness score
+        geomean_perf: Geometric mean of performance scores
+        perf_at_p_score: Performance at threshold p score
+        p: The threshold value used for perf@p calculation
+
+    Structure created:
+        output_path/
+        ├── OVERALL_SUMMARY.md         # Top level summary of results
+        ├── full_results.json          # Complete results log
+        ├── operator_summary.csv       # Operator-level summary
+        └── failed_ops.json            # Log of failed operations
+    """
+    base_dir = Path(output_path)
+    base_dir.mkdir(parents=True, exist_ok=True)
+
+    # Process data using the extracted function
+    all_results, failed_tests, op_summaries = _prepare_results_data(
+        correctness_results, performance_results
+    )
+
+    # 1. Save the full log in the base directory
+    full_log_path = base_dir / "full_results.json"
+    failed_ops_path = base_dir / "failed_ops.json"
+    summary_csv_path = base_dir / "operator_summary.csv"
+
+    with open(full_log_path, "w") as f:
+        json.dump(all_results, f, indent=2)
+    logger.info(f"Full results saved to {full_log_path}")
+
+    # 2. Create operator-level summary CSV
     if len(op_summaries) > 0:
         op_summary_list = list(op_summaries.values())
         fieldnames = list(op_summary_list[0].keys())
@@ -136,13 +160,7 @@ def save_results(
 
         logger.info(f"Operator summary CSV saved to {summary_csv_path}")
 
-    # 4. Save failed operations log
-    failed_tests = [asdict(result) for result in correctness_results if not result.is_correct] + [
-        asdict(result) for result in performance_results if not result.successfully_ran
-    ]
-    # sort failed_tests
-    failed_tests.sort(key=lambda x: (x["op_name"], x["args"]))
-
+    # 3. Save failed operations log
     with open(failed_ops_path, "w") as f:
         json.dump(failed_tests, f, indent=2)
     logger.info(f"Failed operations log saved to {failed_ops_path}")
@@ -203,6 +221,61 @@ def _get_summary_op_results(
     return op_results
 
 
+def _generate_overall_summary_content(
+    command: str,
+    mean_correctness: float,
+    geomean_perf: float,
+    perf_at_p_score: float,
+    p: float = 1.0,
+    performance_results: List[PerformanceTestResult] = None,
+    correctness_results: List[CorrectnessTestResult] = None,
+) -> str:
+    """Generate the content for the overall summary markdown file.
+
+    Returns:
+        The markdown content as a string.
+    """
+    op_results = _get_summary_op_results(performance_results, correctness_results)
+
+    content = []
+    content.append("# BackendBench Run Summary\n")
+
+    content.append("## Command")
+    content.append("```bash")
+    content.append(f"{command}")
+    content.append("```\n")
+
+    content.append("## Results\n")
+    content.append("| Metric | Value |")
+    content.append("|--------|-------|")
+    content.append(f"| Correctness Score | {mean_correctness:.2f} |")
+    content.append(f"| Performance Score (geomean speedup) | {geomean_perf:.2f} |")
+    content.append(f"| Perf@{p} Score | {perf_at_p_score:.2f} |")
+    content.append("")
+
+    content.append("### Metric Descriptions\n")
+    content.append("- **Correctness Score**: Mean pass rate over all operators")
+    content.append("- **Performance Score**: Geometric mean speedup over all operators")
+    content.append(f"- **Perf@{p} Score**: Rate of correct samples with a speedup greater than {p}")
+    content.append("")
+
+    content.append("## Output Files\n")
+    content.append("The following files are saved in this directory:\n")
+    content.append("- `full_results.json`: Complete test results for all operators")
+    content.append("- `operator_summary.csv`: Operator-level summary statistics")
+    content.append("- `failed_ops.json`: Log of failed operations (if any)")
+    content.append("- `OVERALL_SUMMARY.md`: This file")
+
+    content.append("### Operator Speedups vs Eager in Descending Order\n")
+    content.append("| Operator | Correctness Ratio | Speedup vs Eager |")
+    content.append("|----------|-----------|----------------|")
+    for op, correctness, speedup in op_results:
+        content.append(f"| {op} | {correctness} | {speedup}|")
+    content.append("")
+
+    return "\n".join(content)
+
+
 def save_overall_summary(
     output_path: Union[str, Path],
     command: str,
@@ -227,42 +300,18 @@ def save_overall_summary(
     base_dir.mkdir(parents=True, exist_ok=True)
 
     overall_summary_path = base_dir / "OVERALL_SUMMARY.md"
-    op_results = _get_summary_op_results(performance_results, correctness_results)
+
+    content = _generate_overall_summary_content(
+        command,
+        mean_correctness,
+        geomean_perf,
+        perf_at_p_score,
+        p,
+        performance_results,
+        correctness_results,
+    )
 
     with open(overall_summary_path, "w") as f:
-        f.write("# BackendBench Run Summary\n\n")
-
-        f.write("## Command\n")
-        f.write("```bash\n")
-        f.write(f"{command}\n")
-        f.write("```\n\n")
-
-        f.write("## Results\n\n")
-        f.write("| Metric | Value |\n")
-        f.write("|--------|-------|\n")
-        f.write(f"| Correctness Score | {mean_correctness:.2f} |\n")
-        f.write(f"| Performance Score (geomean speedup) | {geomean_perf:.2f} |\n")
-        f.write(f"| Perf@{p} Score | {perf_at_p_score:.2f} |\n")
-        f.write("\n")
-
-        f.write("### Metric Descriptions\n\n")
-        f.write("- **Correctness Score**: Mean pass rate over all operators\n")
-        f.write("- **Performance Score**: Geometric mean speedup over all operators\n")
-        f.write(f"- **Perf@{p} Score**: Rate of correct samples with a speedup greater than {p}\n")
-        f.write("\n")
-
-        f.write("## Output Files\n\n")
-        f.write("The following files are saved in this directory:\n\n")
-        f.write("- `full_results.json`: Complete test results for all operators\n")
-        f.write("- `operator_summary.csv`: Operator-level summary statistics\n")
-        f.write("- `failed_ops.json`: Log of failed operations (if any)\n")
-        f.write("- `OVERALL_SUMMARY.md`: This file\n")
-
-        f.write("### Operator Speedups vs Eager in Descending Order\n\n")
-        f.write("| Operator | Correctness Ratio | Speedup vs Eager |\n")
-        f.write("|----------|-----------|----------------|\n")
-        for op, correctness, speedup in op_results:
-            f.write(f"| {op} | {correctness} | {speedup}|\n")
-        f.write("\n")
+        f.write(content)
 
     logger.info(f"Overall summary saved to {overall_summary_path}")

--- a/BackendBench/output.py
+++ b/BackendBench/output.py
@@ -4,16 +4,17 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 
+import csv
+import json
+import logging
+from collections import defaultdict
 from dataclasses import asdict
 from pathlib import Path
-from typing import List, Union, Tuple
-import json
-import csv
-from collections import defaultdict
-import logging
-from .eval import CorrectnessTestResult, PerformanceTestResult
+from typing import List, Tuple, Union
 
 import torch
+
+from .eval import CorrectnessTestResult, PerformanceTestResult
 
 logger = logging.getLogger(__name__)
 

--- a/BackendBench/output.py
+++ b/BackendBench/output.py
@@ -117,14 +117,14 @@ def _prepare_results_data(
 def save_results(
     correctness_results: List[CorrectnessTestResult],
     performance_results: List[PerformanceTestResult],
-    output_path: Union[str, Path] = "backendbench_output",
-    command: str = None,
-    mean_correctness: float = None,
-    geomean_perf: float = None,
-    perf_at_p_score: float = None,
+    output_path: str,
+    command: str,
+    mean_correctness: float,
+    geomean_perf: float,
+    perf_at_p_score: float,
     p: float = 1.0,
-):
-    """Save results without creating per-operator directories.
+) -> Tuple[List[dict], List[dict], dict]:
+    """Prepare and process results data without file I/O.
 
     Args:
         correctness_results: List of correctness test results

--- a/BackendBench/output.py
+++ b/BackendBench/output.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import List, Tuple, Union
 
 import torch
+import os
 
 from .eval import CorrectnessTestResult, PerformanceTestResult
 
@@ -151,9 +152,9 @@ def save_results(
     )
 
     # 1. Save the full log in the base directory
-    full_log_path = base_dir / "full_results.json"
-    failed_tests_path = base_dir / "failed_tests.json"
-    summary_csv_path = base_dir / "operator_summary.csv"
+    full_log_path = os.path.join(base_dir, "full_results.json")
+    failed_tests_path = os.path.join(base_dir, "failed_tests.json")
+    summary_csv_path = os.path.join(base_dir, "operator_summary.csv")
 
     with open(full_log_path, "w") as f:
         json.dump(all_results, f, indent=2)
@@ -311,7 +312,7 @@ def save_overall_summary(
     base_dir = Path(output_path)
     base_dir.mkdir(parents=True, exist_ok=True)
 
-    overall_summary_path = base_dir / "OVERALL_SUMMARY.md"
+    overall_summary_path = os.path.join(base_dir, "OVERALL_SUMMARY.md")
 
     content = _generate_overall_summary_content(
         command,

--- a/BackendBench/output.py
+++ b/BackendBench/output.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import List, Tuple, Union
 
 import torch
+import os
 
 from .eval import CorrectnessTestResult, PerformanceTestResult
 

--- a/BackendBench/output.py
+++ b/BackendBench/output.py
@@ -14,7 +14,6 @@ from pathlib import Path
 from typing import List, Tuple, Union
 
 import torch
-import os
 
 from .eval import CorrectnessTestResult, PerformanceTestResult
 

--- a/BackendBench/output.py
+++ b/BackendBench/output.py
@@ -7,13 +7,13 @@
 import csv
 import json
 import logging
+import os
 from collections import defaultdict
 from dataclasses import asdict
 from pathlib import Path
 from typing import List, Tuple, Union
 
 import torch
-import os
 
 from .eval import CorrectnessTestResult, PerformanceTestResult
 

--- a/BackendBench/prompts.py
+++ b/BackendBench/prompts.py
@@ -10,7 +10,7 @@ Operation: {op_signature}
 {op_description}
 
 Requirements:
-- Triton kernel function MUST be named: {op_name}_triton_kernel  
+- Triton kernel function MUST be named: {op_name}_triton_kernel
 - Wrapper function MUST be named: {op_name}_kernel_impl
 - Use modern Triton syntax with proper grid computation
 - Include all necessary imports (torch, triton, triton.language as tl)

--- a/BackendBench/scripts/create_simple_test_ops.py
+++ b/BackendBench/scripts/create_simple_test_ops.py
@@ -11,8 +11,8 @@ Create simple kernel implementations for 5 common operations.
 Each just calls the original PyTorch function.
 """
 
-import os
 import logging
+import os
 
 logger = logging.getLogger(__name__)
 

--- a/BackendBench/scripts/create_watermarked_operators.py
+++ b/BackendBench/scripts/create_watermarked_operators.py
@@ -11,11 +11,10 @@ Create watermarked operator implementations that return constant tensors.
 These implementations will verify monkey patching works but will fail correctness tests.
 """
 
-import os
 import argparse
 import hashlib
+import os
 from pathlib import Path
-
 
 WATERMARK_BASE = 42.0
 

--- a/BackendBench/scripts/dataset_filters.py
+++ b/BackendBench/scripts/dataset_filters.py
@@ -6,15 +6,15 @@
 
 
 import torch
-
 import tqdm
-from BackendBench.utils import cleanup_memory_and_gpu, deserialize_args
 from triton.testing import do_bench
+
 from BackendBench.op_categories import (
-    UNSUPPORTED_OPERATORS,
-    TENSOR_CREATION_AND_MANIPULATION_OPS,
     RANDOM_OPS,
+    TENSOR_CREATION_AND_MANIPULATION_OPS,
+    UNSUPPORTED_OPERATORS,
 )
+from BackendBench.utils import cleanup_memory_and_gpu, deserialize_args
 
 # We get this threshhold from the analysis here
 # https://github.com/meta-pytorch/BackendBench/issues/108

--- a/BackendBench/scripts/get_big_inputs.py
+++ b/BackendBench/scripts/get_big_inputs.py
@@ -14,7 +14,10 @@ from typing import Dict, List, Tuple
 
 import requests
 import torch
+from main import setup_logging
+from tqdm import tqdm
 
+from BackendBench.op_categories import UNSUPPORTED_OPERATORS
 from BackendBench.torchbench_suite import (
     _args_size,
     _deserialize_args,
@@ -22,9 +25,6 @@ from BackendBench.torchbench_suite import (
     _parse_inputs,
     dtype_abbrs,
 )
-from BackendBench.op_categories import UNSUPPORTED_OPERATORS
-from main import setup_logging
-from tqdm import tqdm
 from BackendBench.utils import cleanup_memory_and_gpu
 
 # Magic numbers and constants

--- a/BackendBench/scripts/get_tests_stat.py
+++ b/BackendBench/scripts/get_tests_stat.py
@@ -11,7 +11,9 @@ This is a helper script to analyze the test suite and provide statistics about t
 import statistics
 
 import torch
-from BackendBench.suite import OpInfoTestSuite, TorchBenchTestSuite, FactoTestSuite
+
+from BackendBench.suite import FactoTestSuite, OpInfoTestSuite, TorchBenchTestSuite
+
 from .setup_operator_directories import extract_operator_name
 
 

--- a/BackendBench/scripts/main.py
+++ b/BackendBench/scripts/main.py
@@ -4,19 +4,19 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 
+import datetime
 import logging
 import os
 import sys
 
-import BackendBench.backends as backends
-import BackendBench.eval as eval
-from BackendBench.output import save_results
-import BackendBench.multiprocessing_eval as multiprocessing_eval
 import click
 import torch
-import datetime
 
+import BackendBench.backends as backends
+import BackendBench.eval as eval
+import BackendBench.multiprocessing_eval as multiprocessing_eval
 from BackendBench.llm_client import LLMKernelGenerator, LLMRelayKernelGenerator
+from BackendBench.output import save_results
 from BackendBench.suite import (
     FactoTestSuite,
     OpInfoTestSuite,

--- a/BackendBench/scripts/parquet_trace_converter.py
+++ b/BackendBench/scripts/parquet_trace_converter.py
@@ -16,12 +16,13 @@ import click
 import numpy as np
 import pyarrow as pa
 import pyarrow.parquet as pq
+from huggingface_hub import HfApi
+
 from BackendBench.data_loaders import _load_from_trace
 from BackendBench.scripts.dataset_filters import (
     apply_runtime_filter,
     apply_skip_ops_filter,
 )
-from huggingface_hub import HfApi
 
 DEFAULT_TRACE_URL = "https://huggingface.co/datasets/GPUMODE/huggingface_op_trace/resolve/main/augmented_hf_op_traces.txt"
 DEFAULT_PARQUET_URL = "https://huggingface.co/datasets/GPUMODE/huggingface_op_trace/resolve/main/backend_bench_problems.parquet"

--- a/BackendBench/scripts/setup_operator_directories.py
+++ b/BackendBench/scripts/setup_operator_directories.py
@@ -67,6 +67,7 @@ def get_opinfo_operators() -> Set[str]:
     """Get operators available in OpInfo suite."""
     try:
         import torch
+
         from BackendBench.suite import OpInfoTestSuite
 
         suite = OpInfoTestSuite("opinfo", "cpu", torch.float32)

--- a/BackendBench/suite/facto.py
+++ b/BackendBench/suite/facto.py
@@ -22,6 +22,7 @@ except ImportError:
 
 from BackendBench.eval import allclose
 from BackendBench.opregistry import get_operator
+
 from .base import OpTest, TestSuite
 
 logger = logging.getLogger(__name__)

--- a/BackendBench/suite/opinfo.py
+++ b/BackendBench/suite/opinfo.py
@@ -11,6 +11,7 @@ from torch.testing._internal.common_methods_invocations import op_db
 from torch.utils._python_dispatch import TorchDispatchMode
 
 from BackendBench.eval import allclose
+
 from .base import OpTest, TestSuite
 
 logger = logging.getLogger(__name__)

--- a/BackendBench/suite/smoke.py
+++ b/BackendBench/suite/smoke.py
@@ -7,7 +7,8 @@
 import torch
 
 from BackendBench.opregistry import get_operator
-from .base import Test, OpTest, TestSuite
+
+from .base import OpTest, Test, TestSuite
 
 
 def randn(*args, **kwargs):

--- a/BackendBench/suite/torchbench.py
+++ b/BackendBench/suite/torchbench.py
@@ -26,6 +26,7 @@ Use scripts/parquet_to_trace.py to generate and upload new datasets to HuggingFa
 """
 
 import torch  # noqa: F401
+
 from BackendBench.data_loaders import (
     _args_size,
     load_ops_from_source,

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ python -m BackendBench.scripts.setup_operator_directories
 
 2. **Implement kernels** in each directory you'll see an empty op implementation. Please get your LLM to fill it out!
 
-```bash
 3. **Test your implementations**:
+
+```bash
 # OpInfo correctness tests
 python BackendBench/scripts/main.py --suite opinfo --backend directory
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,4 +61,11 @@ dev-dependencies = [
 [tool.ruff]
 line-length = 100
 
-[tool.ruff.format]
+[tool.ruff.lint]
+extend-select = ["I", "W292", "W291"]  # Enable isort rules, final newline rule, and trailing whitespace rule
+
+[tool.ruff.lint.isort]
+case-sensitive = false
+combine-as-imports = true
+detect-same-package = false
+order-by-type = false

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,1 @@
+# Test module initialization

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,5 +1,0 @@
-# Copyright (c) Meta Platforms, Inc. and affiliates.
-# All rights reserved.
-#
-# This source code is licensed under the BSD 3-Clause license found in the
-# LICENSE file in the root directory of this source tree.

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,1 +1,5 @@
-# Test module initialization
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.

--- a/test/test_adverse_cases.py
+++ b/test/test_adverse_cases.py
@@ -5,10 +5,11 @@
 # LICENSE file in the root directory of this source tree.
 
 import pytest
-from BackendBench.suite import TorchBenchOpTest
-import BackendBench.multiprocessing_eval as multiprocessing_eval
-import BackendBench.backends as backends
 import torch
+
+import BackendBench.backends as backends
+import BackendBench.multiprocessing_eval as multiprocessing_eval
+from BackendBench.suite import TorchBenchOpTest
 
 
 class TestAdaptiveAvgPool2dBackward:

--- a/test/test_backend_evaluation.py
+++ b/test/test_backend_evaluation.py
@@ -6,9 +6,9 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 
+import subprocess
 import sys
 import unittest
-import subprocess
 from pathlib import Path
 
 import torch

--- a/test/test_backends.py
+++ b/test/test_backends.py
@@ -5,14 +5,15 @@
 # LICENSE file in the root directory of this source tree.
 
 import importlib.util
+
 import pytest
 import torch
+
 from BackendBench.backends import (
     AtenBackend,
     FlagGemsBackend,
     KernelAgentBackend,
 )
-
 
 HAS_KERNEL_AGENT = KernelAgentBackend is not None
 

--- a/test/test_directory_backend.py
+++ b/test/test_directory_backend.py
@@ -15,6 +15,7 @@ sys.path.insert(0, ".")
 
 import pytest
 import torch
+
 from BackendBench.backends import DirectoryBackend
 
 

--- a/test/test_eval.py
+++ b/test/test_eval.py
@@ -9,6 +9,7 @@ import importlib.util
 import numpy as np
 import pytest
 import torch
+
 from BackendBench.eval import (
     allclose,
     cpu_bench,

--- a/test/test_facto_suite.py
+++ b/test/test_facto_suite.py
@@ -4,14 +4,14 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 
+import importlib.util
+
 import pytest
 import torch
 
 import BackendBench.backends as backends
 from BackendBench.eval import eval_one_op
 from BackendBench.suite import FactoTestSuite
-
-import importlib.util
 
 HAS_FACTO_DEPS = importlib.util.find_spec("facto") is not None
 

--- a/test/test_model_with_embedded_kernels.py
+++ b/test/test_model_with_embedded_kernels.py
@@ -11,14 +11,15 @@ Test for backend registration that sets up the generated kernels directory struc
 from scratch with embedded implementations and verifies custom operator registration.
 """
 
+import io
 import os
 import shutil
 import tempfile
 import unittest
-import io
 from contextlib import redirect_stdout
 
 import torch
+
 import BackendBench
 
 

--- a/test/test_monkey_patch.py
+++ b/test/test_monkey_patch.py
@@ -11,11 +11,11 @@ Test monkey patching of directory backend.
 """
 
 import os
-import sys
 import shutil
 import subprocess
-import pytest
+import sys
 
+import pytest
 import torch
 
 import BackendBench

--- a/test/test_output.py
+++ b/test/test_output.py
@@ -5,20 +5,19 @@
 # LICENSE file in the root directory of this source tree.
 
 import json
+import math
 import tempfile
 from pathlib import Path
-import math
 
 from expecttest import assert_expected_inline
 
-
 from BackendBench.eval import CorrectnessTestResult, PerformanceTestResult
 from BackendBench.output import (
-    _prepare_results_data,
-    _get_summary_op_results,
     _generate_overall_summary_content,
-    save_results,
+    _get_summary_op_results,
+    _prepare_results_data,
     save_overall_summary,
+    save_results,
 )
 
 

--- a/test/test_output.py
+++ b/test/test_output.py
@@ -1,0 +1,342 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD 3-Clause license found in the
+# LICENSE file in the root directory of this source tree.
+
+import json
+import tempfile
+from pathlib import Path
+import math
+
+from expecttest import TestCase
+
+from BackendBench.eval import CorrectnessTestResult, PerformanceTestResult
+from BackendBench.output import (
+    _prepare_results_data,
+    _get_summary_op_results,
+    _generate_overall_summary_content,
+    save_results,
+    save_overall_summary,
+)
+
+
+class TestOutputFunctions(TestCase):
+    def _create_test_fixtures(self):
+        """Create test fixtures for correctness and performance results."""
+        correctness_results = [
+            CorrectnessTestResult(
+                op_name="torch.ops.aten.add.Tensor",
+                args="[tensor([1, 2]), tensor([3, 4])]",
+                is_correct=True,
+                max_abs_error=0.001,
+                max_rel_error=0.0001,
+            ),
+            CorrectnessTestResult(
+                op_name="torch.ops.aten.add.Tensor",
+                args="[tensor([5, 6]), tensor([7, 8])]",
+                is_correct=True,
+                max_abs_error=0.002,
+                max_rel_error=0.0002,
+            ),
+            CorrectnessTestResult(
+                op_name="torch.ops.aten.mul.Tensor",
+                args="[tensor([1, 2]), tensor([3, 4])]",
+                is_correct=False,
+                error_msg="Tensor mismatch",
+                error_type="AssertionError",
+            ),
+            CorrectnessTestResult(
+                op_name="torch.ops.aten.sin.default",
+                args="[tensor([0.5])]",
+                is_correct=True,
+                max_abs_error=0.0,
+                max_rel_error=0.0,
+            ),
+        ]
+
+        performance_results = [
+            PerformanceTestResult(
+                op_name="torch.ops.aten.add.Tensor",
+                args="[tensor([1, 2]), tensor([3, 4])]",
+                speedup=1.5,
+                benchmark_time_ms=10.0,
+                reference_time_ms=15.0,
+                successfully_ran=True,
+            ),
+            PerformanceTestResult(
+                op_name="torch.ops.aten.add.Tensor",
+                args="[tensor([5, 6]), tensor([7, 8])]",
+                speedup=2.0,
+                benchmark_time_ms=8.0,
+                reference_time_ms=16.0,
+                successfully_ran=True,
+            ),
+            PerformanceTestResult(
+                op_name="torch.ops.aten.mul.Tensor",
+                args="[tensor([1, 2]), tensor([3, 4])]",
+                speedup=0.0,
+                benchmark_time_ms=0.0,
+                reference_time_ms=20.0,
+                successfully_ran=False,
+                error_msg="Compilation failed",
+            ),
+            PerformanceTestResult(
+                op_name="torch.ops.aten.sin.default",
+                args="[tensor([0.5])]",
+                speedup=3.0,
+                benchmark_time_ms=5.0,
+                reference_time_ms=15.0,
+                successfully_ran=True,
+            ),
+        ]
+
+        return correctness_results, performance_results
+
+    def test_prepare_results_data(self):
+        """Test the _prepare_results_data function."""
+        correctness_results, performance_results = self._create_test_fixtures()
+
+        all_results, failed_tests, op_summaries = _prepare_results_data(
+            correctness_results, performance_results
+        )
+
+        # Check that all results are properly converted to dicts and sorted
+        self.assertEqual(len(all_results), 8)  # 4 correctness + 4 performance
+
+        # Check sorting by op_name, then args
+        expected_order = [
+            "torch.ops.aten.add.Tensor",
+            "torch.ops.aten.add.Tensor",
+            "torch.ops.aten.add.Tensor",
+            "torch.ops.aten.add.Tensor",
+            "torch.ops.aten.mul.Tensor",
+            "torch.ops.aten.mul.Tensor",
+            "torch.ops.aten.sin.default",
+            "torch.ops.aten.sin.default",
+        ]
+        actual_order = [result["op_name"] for result in all_results]
+        self.assertEqual(actual_order, expected_order)
+
+        # Check failed tests
+        self.assertEqual(len(failed_tests), 2)  # 1 correctness + 1 performance failure
+        failed_ops = [test["op_name"] for test in failed_tests]
+        self.assertIn("torch.ops.aten.mul.Tensor", failed_ops)
+
+        # Check operator summaries
+        self.assertEqual(len(op_summaries), 3)  # add, mul, sin
+
+        # Test add operator summary
+        add_summary = op_summaries["torch.ops.aten.add.Tensor"]
+        self.assertExpectedInline(
+            str(add_summary),
+            """{'operator': 'torch.ops.aten.add.Tensor', 'total_tests': 4, 'passed_tests': 2, 'failed_tests': 2, 'correctness_rate': 0.5, 'avg_speedup': 1.75, 'geomean_speedup': 1.7320507764816284, 'max_absolute_error': 0.002, 'max_relative_error': 0.0002}""",
+        )
+
+        # Test mul operator summary (should have failed correctness and performance)
+        mul_summary = op_summaries["torch.ops.aten.mul.Tensor"]
+        self.assertExpectedInline(
+            str(mul_summary),
+            """{'operator': 'torch.ops.aten.mul.Tensor', 'total_tests': 2, 'passed_tests': 0, 'failed_tests': 2, 'correctness_rate': 0.0, 'avg_speedup': 0.0, 'geomean_speedup': 0.0, 'max_absolute_error': -inf, 'max_relative_error': -inf}""",
+        )
+
+    def test_get_summary_op_results(self):
+        """Test the _get_summary_op_results function."""
+        correctness_results, performance_results = self._create_test_fixtures()
+
+        op_results = _get_summary_op_results(performance_results, correctness_results)
+
+        # Should return list of tuples (op_name, correctness_str, speedup_str)
+        self.assertEqual(len(op_results), 3)
+
+        # Check that results are sorted properly (by speedup descending, then correctness)
+        self.assertExpectedInline(
+            str(op_results),
+            """\
+[('torch.ops.aten.sin.default', '1.0000%', '3.0000x'), ('torch.ops.aten.add.Tensor', '1.0000%', '1.7500x'), ('torch.ops.aten.mul.Tensor', '0.0000%', '1.0000x')]""",
+        )
+
+    def test_generate_overall_summary_content(self):
+        """Test the _generate_overall_summary_content function."""
+        correctness_results, performance_results = self._create_test_fixtures()
+
+        content = _generate_overall_summary_content(
+            command="backendbench --suite test_suite",
+            mean_correctness=0.75,
+            geomean_perf=1.8,
+            perf_at_p_score=0.6,
+            p=1.2,
+            performance_results=performance_results,
+            correctness_results=correctness_results,
+        )
+
+        self.assertExpectedInline(
+            content,
+            """\
+# BackendBench Run Summary
+
+## Command
+```bash
+backendbench --suite test_suite
+```
+
+## Results
+
+| Metric | Value |
+|--------|-------|
+| Correctness Score | 0.75 |
+| Performance Score (geomean speedup) | 1.80 |
+| Perf@1.2 Score | 0.60 |
+
+### Metric Descriptions
+
+- **Correctness Score**: Mean pass rate over all operators
+- **Performance Score**: Geometric mean speedup over all operators
+- **Perf@1.2 Score**: Rate of correct samples with a speedup greater than 1.2
+
+## Output Files
+
+The following files are saved in this directory:
+
+- `full_results.json`: Complete test results for all operators
+- `operator_summary.csv`: Operator-level summary statistics
+- `failed_ops.json`: Log of failed operations (if any)
+- `OVERALL_SUMMARY.md`: This file
+### Operator Speedups vs Eager in Descending Order
+
+| Operator | Correctness Ratio | Speedup vs Eager |
+|----------|-----------|----------------|
+| torch.ops.aten.sin.default | 1.0000% | 3.0000x|
+| torch.ops.aten.add.Tensor | 1.0000% | 1.7500x|
+| torch.ops.aten.mul.Tensor | 0.0000% | 1.0000x|
+""",
+        )
+
+    def test_save_results_integration(self):
+        """Test the full save_results function with file I/O."""
+        correctness_results, performance_results = self._create_test_fixtures()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "test_output"
+
+            save_results(
+                correctness_results=correctness_results,
+                performance_results=performance_results,
+                output_path=output_path,
+                command="backendbench --suite test_suite",
+                mean_correctness=0.75,
+                geomean_perf=1.8,
+                perf_at_p_score=0.6,
+                p=1.2,
+            )
+
+            # Check that all expected files were created
+            self.assertTrue((output_path / "full_results.json").exists())
+            self.assertTrue((output_path / "operator_summary.csv").exists())
+            self.assertTrue((output_path / "failed_ops.json").exists())
+            self.assertTrue((output_path / "OVERALL_SUMMARY.md").exists())
+
+            # Check full_results.json content
+            with open(output_path / "full_results.json") as f:
+                full_results = json.load(f)
+            self.assertEqual(len(full_results), 8)
+
+            # Check failed_ops.json content
+            with open(output_path / "failed_ops.json") as f:
+                failed_ops = json.load(f)
+            self.assertEqual(len(failed_ops), 2)
+
+            # Check that CSV has correct number of rows (header + 3 operators)
+            with open(output_path / "operator_summary.csv") as f:
+                csv_content = f.read()
+            # Should have header + 3 data rows
+            self.assertEqual(len(csv_content.strip().split("\n")), 4)
+
+            # Check overall summary exists and has expected content
+            with open(output_path / "OVERALL_SUMMARY.md") as f:
+                summary_content = f.read()
+            self.assertIn("# BackendBench Run Summary", summary_content)
+            self.assertIn("backendbench --suite test_suite", summary_content)
+            self.assertIn("0.75", summary_content)  # mean_correctness
+            self.assertIn("1.80", summary_content)  # geomean_perf
+
+    def test_save_overall_summary_standalone(self):
+        """Test the save_overall_summary function independently."""
+        correctness_results, performance_results = self._create_test_fixtures()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "test_summary"
+
+            save_overall_summary(
+                output_path=output_path,
+                command="backendbench --ops add,mul",
+                mean_correctness=0.8,
+                geomean_perf=2.1,
+                perf_at_p_score=0.7,
+                p=1.5,
+                performance_results=performance_results,
+                correctness_results=correctness_results,
+            )
+
+            # Check that the summary file was created
+            summary_path = output_path / "OVERALL_SUMMARY.md"
+            self.assertTrue(summary_path.exists())
+
+            # Check content
+            with open(summary_path) as f:
+                content = f.read()
+
+            self.assertIn("backendbench --ops add,mul", content)
+            self.assertIn("| Correctness Score | 0.80 |", content)
+            self.assertIn("| Performance Score (geomean speedup) | 2.10 |", content)
+            self.assertIn("| Perf@1.5 Score | 0.70 |", content)
+
+    def test_empty_results(self):
+        """Test functions with empty input data."""
+        empty_correctness = []
+        empty_performance = []
+
+        all_results, failed_tests, op_summaries = _prepare_results_data(
+            empty_correctness, empty_performance
+        )
+
+        self.assertEqual(len(all_results), 0)
+        self.assertEqual(len(failed_tests), 0)
+        self.assertEqual(len(op_summaries), 0)
+
+        # Test with empty results in summary function
+        op_results = _get_summary_op_results(empty_performance, empty_correctness)
+        self.assertEqual(len(op_results), 0)
+
+    def test_edge_cases(self):
+        """Test edge cases and error conditions."""
+        # Test with NaN and infinite values
+        edge_case_results = [
+            CorrectnessTestResult(
+                op_name="edge_case_op",
+                args="[tensor([nan])]",
+                is_correct=True,
+                max_abs_error=float("inf"),
+                max_rel_error=-math.inf,
+            ),
+            PerformanceTestResult(
+                op_name="edge_case_op",
+                args="[tensor([nan])]",
+                speedup=float("inf"),
+                benchmark_time_ms=0.0,
+                reference_time_ms=1.0,
+                successfully_ran=True,
+            ),
+        ]
+
+        all_results, failed_tests, op_summaries = _prepare_results_data(
+            [edge_case_results[0]], [edge_case_results[1]]
+        )
+
+        # Should handle infinite values gracefully
+        self.assertEqual(len(all_results), 2)
+        self.assertEqual(len(op_summaries), 1)
+
+        # Check that infinite speedup is handled
+        edge_summary = op_summaries["edge_case_op"]
+        self.assertTrue(math.isinf(edge_summary["avg_speedup"]))

--- a/test/test_smoke.py
+++ b/test/test_smoke.py
@@ -4,21 +4,13 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 
+
 import pytest
 import torch
 
-try:
-    import importlib.util
-
-    import BackendBench.backends as backends
-    from BackendBench.eval import eval_one_op
-    from BackendBench.suite import SmokeTestSuite
-
-    HAS_TRITON = importlib.util.find_spec("triton") is not None
-except ImportError:
-    HAS_TRITON = False
-
-pytestmark = pytest.mark.skipif(not HAS_TRITON, reason="triton not available")
+import BackendBench.backends as backends
+from BackendBench.eval import eval_one_op
+from BackendBench.suite import SmokeTestSuite
 
 
 class TestSmoke:

--- a/test/test_smoke.py
+++ b/test/test_smoke.py
@@ -9,9 +9,10 @@ import torch
 
 try:
     import importlib.util
-    from BackendBench.suite import SmokeTestSuite
-    from BackendBench.eval import eval_one_op
+
     import BackendBench.backends as backends
+    from BackendBench.eval import eval_one_op
+    from BackendBench.suite import SmokeTestSuite
 
     HAS_TRITON = importlib.util.find_spec("triton") is not None
 except ImportError:

--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -6,8 +6,9 @@
 
 import pytest
 import torch
-from BackendBench.suite import randn, Test, OpTest, TestSuite, SmokeTestSuite
+
 from BackendBench.opregistry import get_operator
+from BackendBench.suite import OpTest, randn, SmokeTestSuite, Test, TestSuite
 
 
 class TestRandnFunction:

--- a/test/test_torchbench_suite.py
+++ b/test/test_torchbench_suite.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import torch
+
 from BackendBench.suite import TorchBenchOpTest
 
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -4,16 +4,17 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 
-import torch
 import math
+
 import pytest
+import torch
 
 from BackendBench.utils import (
-    serialize_args,
-    deserialize_args,
     _deserialize_tensor,
-    uses_cuda_stream,
     compute_errors,
+    deserialize_args,
+    serialize_args,
+    uses_cuda_stream,
 )
 
 # Check if CUDA is available


### PR DESCRIPTION
This PR primarily does 3 things
1. Refractors the output logic to split out the I/O components and actual content writing
2. Writes tests for the content bits using [expectest](https://pypi.org/project/expecttest/)
3. Modifies the op summary csv output to be more correct. Specifically, we break out failed correctness and performance tests. 

For reviewers: Given how short output.py is, I'd honestly recommend just reading that to do the review as a lot of code was moved around. For testing test_output.py is fairly comprehensive. 