### PR TITLE
WIP: make compile_kernel_from_string as an util

### DIFF
--- a/BackendBench/backends/kernel_agent.py
+++ b/BackendBench/backends/kernel_agent.py
@@ -188,7 +188,12 @@ def {expected_name}(*args, **kwargs):
         expected_fn_name = f"{op_name}_kernel_impl"
 
         try:
-            kernel = compile_kernel_from_string(kernel_code=adapted_code, op_name=op_name, kernel_file_path=kernel_file_path, expected_fn_name=expected_fn_name)
+            kernel = compile_kernel_from_string(
+                kernel_code=adapted_code,
+                op_name=op_name,
+                kernel_file_path=kernel_file_path,
+                expected_fn_name=expected_fn_name,
+            )
         except Exception as e:
             raise e
         return kernel

--- a/BackendBench/backends/kernel_agent.py
+++ b/BackendBench/backends/kernel_agent.py
@@ -4,14 +4,13 @@
 # This source code is licensed under the BSD 3-Clause license found in the
 # LICENSE file in the root directory of this source tree.
 
-import importlib.util
 import logging
 import os
 from typing import Callable, Dict
 
-from .base import Backend
-
 from BackendBench.utils import compile_kernel_from_string
+
+from .base import Backend
 
 logger = logging.getLogger(__name__)
 

--- a/BackendBench/backends/kernel_agent.py
+++ b/BackendBench/backends/kernel_agent.py
@@ -185,6 +185,7 @@ def {expected_name}(*args, **kwargs):
         adapted_code = self._adapt_kernel_function_name(kernel_code, op_name)
         kernel_file_path = os.path.join(self.kernels_dir, f"{op_name}_kernel.py")
         expected_fn_name = f"{op_name}_kernel_impl"
+        module_name = f"kernel_agent_{op_name}"
 
         try:
             kernel = compile_kernel_from_string(
@@ -192,6 +193,7 @@ def {expected_name}(*args, **kwargs):
                 op_name=op_name,
                 kernel_file_path=kernel_file_path,
                 expected_fn_name=expected_fn_name,
+                module_name=module_name,
             )
         except Exception as e:
             raise e

--- a/BackendBench/backends/kernel_agent.py
+++ b/BackendBench/backends/kernel_agent.py
@@ -193,27 +193,6 @@ def {expected_name}(*args, **kwargs):
             raise e
         return kernel
 
-    def _prepare_triton_code(self, kernel_code: str) -> str:
-        """Prepare Triton kernel code with necessary imports."""
-        imports = """
-import torch
-import triton
-import triton.language as tl
-"""
-        if "import torch" not in kernel_code:
-            kernel_code = imports + kernel_code
-        return kernel_code
-
-    def _prepare_torch_code(self, kernel_code: str) -> str:
-        """Prepare regular PyTorch kernel code with necessary imports."""
-        imports = """
-import torch
-import torch.nn.functional as F
-"""
-        if "import torch" not in kernel_code:
-            kernel_code = imports + kernel_code
-        return kernel_code
-
     def add_kernel(self, op, kernel_code: str, op_name: str):
         """Add a kernel implementation for a specific operator."""
         compiled_kernel = self.compile_kernel_from_string(kernel_code, op_name, attempt=1)

--- a/BackendBench/backends/llm.py
+++ b/BackendBench/backends/llm.py
@@ -16,7 +16,7 @@ import torch
 
 from BackendBench.llm_client import LLMKernelGenerator
 from BackendBench.multiprocessing_eval import MultiprocessingEvaluator
-from BackendBench.utils import extract_operator_name, compile_kernel_from_string
+from BackendBench.utils import compile_kernel_from_string, extract_operator_name
 
 from .base import Backend
 

--- a/BackendBench/backends/llm.py
+++ b/BackendBench/backends/llm.py
@@ -16,7 +16,7 @@ import torch
 
 from BackendBench.llm_client import LLMKernelGenerator
 from BackendBench.multiprocessing_eval import MultiprocessingEvaluator
-from BackendBench.utils import extract_operator_name
+from BackendBench.utils import extract_operator_name, compile_kernel_from_string
 
 from .base import Backend
 
@@ -112,76 +112,19 @@ You can inspect these files to debug kernel generation, manually test implementa
     def compile_kernel_from_string(
         self, kernel_code: str, op_name: str, attempt: int = 1
     ) -> Callable:
-        """Compile a kernel from string code and return a callable."""
+        """ Compile a kernel from string code and return a callable."""
+        op_dir = os.path.join(self.kernels_dir, op_name)
+        os.makedirs(op_dir, exist_ok=True)
+        kernel_file_path = os.path.join(op_dir, f"{op_name}_implementation_v{attempt}.py")
+        expected_fn_name = f"{op_name}_implementation_v{attempt}"
+
         try:
-            is_triton = "triton.jit" in kernel_code or "@triton.jit" in kernel_code
-
-            if is_triton:
-                full_code = self._prepare_triton_code(kernel_code)
-            else:
-                full_code = self._prepare_torch_code(kernel_code)
-
-            # create directory / file in the directory bench format
-            op_dir = os.path.join(self.kernels_dir, op_name)
-            os.makedirs(op_dir, exist_ok=True)
-            kernel_file = os.path.join(op_dir, f"{op_name}_implementation_v{attempt}.py")
-            with open(kernel_file, "w") as f:
-                f.write(full_code)
-
-            logger.debug(f"Saved kernel to: {kernel_file}")
-
-            spec = importlib.util.spec_from_file_location(
-                f"{op_name}_implementation_v{attempt}", kernel_file
+            kernel = compile_kernel_from_string(
+                kernel_code=kernel_code, op_name=op_name, kernel_file_path=kernel_file_path, expected_fn_name=expected_fn_name
             )
-            module = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(module)
-
-            kernel_func = self._find_kernel_function(module, op_name)
-
-            return kernel_func
-
         except Exception as e:
-            raise RuntimeError(f"Failed to compile kernel for {op_name}: {str(e)}")
-
-    def _prepare_triton_code(self, kernel_code: str) -> str:
-        """Prepare Triton kernel code with necessary imports."""
-        imports = """
-import torch
-import triton
-import triton.language as tl
-"""
-        if "import torch" not in kernel_code:
-            kernel_code = imports + kernel_code
-        return kernel_code
-
-    def _prepare_torch_code(self, kernel_code: str) -> str:
-        """Prepare regular PyTorch kernel code with necessary imports."""
-        imports = """
-import torch
-import torch.nn.functional as F
-"""
-        if "import torch" not in kernel_code:
-            kernel_code = imports + kernel_code
-        return kernel_code
-
-    def _find_kernel_function(self, module, op_name: str) -> Callable:
-        """Find the main kernel function in the compiled module."""
-        expected_name = f"{op_name}_kernel_impl"
-
-        if hasattr(module, expected_name):
-            return getattr(module, expected_name)
-
-        available_functions = [
-            name
-            for name in dir(module)
-            if callable(getattr(module, name)) and not name.startswith("_")
-        ]
-
-        raise ValueError(
-            f"Expected function '{expected_name}' not found in kernel code for {op_name}. "
-            f"Available functions: {available_functions}. "
-            f"Please ensure the LLM generated code follows the naming convention: {op_name}_kernel_impl"
-        )
+            raise e
+        return kernel
 
     def _make_error_func(error_msg):
         def error_func(*args, **kwargs):

--- a/BackendBench/backends/llm.py
+++ b/BackendBench/backends/llm.py
@@ -116,14 +116,15 @@ You can inspect these files to debug kernel generation, manually test implementa
         op_dir = os.path.join(self.kernels_dir, op_name)
         os.makedirs(op_dir, exist_ok=True)
         kernel_file_path = os.path.join(op_dir, f"{op_name}_implementation_v{attempt}.py")
-        expected_fn_name = f"{op_name}_implementation_v{attempt}"
+        module_name = f"{op_name}_implementation_v{attempt}"
 
         try:
             kernel = compile_kernel_from_string(
                 kernel_code=kernel_code,
                 op_name=op_name,
                 kernel_file_path=kernel_file_path,
-                expected_fn_name=expected_fn_name,
+                expected_fn_name=op_name,
+                module_name=module_name,
             )
         except Exception as e:
             raise e

--- a/BackendBench/backends/llm.py
+++ b/BackendBench/backends/llm.py
@@ -112,7 +112,7 @@ You can inspect these files to debug kernel generation, manually test implementa
     def compile_kernel_from_string(
         self, kernel_code: str, op_name: str, attempt: int = 1
     ) -> Callable:
-        """ Compile a kernel from string code and return a callable."""
+        """Compile a kernel from string code and return a callable."""
         op_dir = os.path.join(self.kernels_dir, op_name)
         os.makedirs(op_dir, exist_ok=True)
         kernel_file_path = os.path.join(op_dir, f"{op_name}_implementation_v{attempt}.py")
@@ -120,7 +120,10 @@ You can inspect these files to debug kernel generation, manually test implementa
 
         try:
             kernel = compile_kernel_from_string(
-                kernel_code=kernel_code, op_name=op_name, kernel_file_path=kernel_file_path, expected_fn_name=expected_fn_name
+                kernel_code=kernel_code,
+                op_name=op_name,
+                kernel_file_path=kernel_file_path,
+                expected_fn_name=expected_fn_name,
             )
         except Exception as e:
             raise e

--- a/BackendBench/utils.py
+++ b/BackendBench/utils.py
@@ -282,7 +282,7 @@ def extract_operator_name(op_str: str) -> str:
 
 
 def compile_kernel_from_string(
-    kernel_code: str, op_name: str, kernel_file_path: str, expected_fn_name: str
+    kernel_code: str, op_name: str, kernel_file_path: str, expected_fn_name: str, module_name: str
 ) -> tuple[Callable | None, list[str]]:
     def _prepare_triton_code(kernel_code: str) -> str:
         """Prepare Triton kernel code with necessary imports."""
@@ -337,11 +337,11 @@ import torch.nn.functional as F
 
         logger.debug(f"Saved kernel to: {kernel_file_path}")
 
-        spec = importlib.util.spec_from_file_location(expected_fn_name, kernel_file_path)
+        spec = importlib.util.spec_from_file_location(module_name, kernel_file_path)
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
 
-        kernel_func = _find_kernel_function(module, op_name)
+        kernel_func = _find_kernel_function(module, expected_fn_name)
         return kernel_func
 
     except Exception as e:

--- a/BackendBench/utils.py
+++ b/BackendBench/utils.py
@@ -6,17 +6,16 @@
 
 import ast
 import gc
+import importlib.util
 import inspect
 import logging
 import math
 import re
 import textwrap
-import importlib.util
+from typing import Callable
 
 import torch
 from torch.testing import make_tensor
-
-from typing import Callable
 
 logger = logging.getLogger(__name__)
 

--- a/BackendBench/utils.py
+++ b/BackendBench/utils.py
@@ -338,9 +338,7 @@ import torch.nn.functional as F
 
         logger.debug(f"Saved kernel to: {kernel_file_path}")
 
-        spec = importlib.util.spec_from_file_location(
-            expected_fn_name, kernel_file_path
-        )
+        spec = importlib.util.spec_from_file_location(expected_fn_name, kernel_file_path)
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
 


### PR DESCRIPTION
both kernel_agent and llm backends reuse basically the same functionality to compile the kernel from string. This can be abstracted away into utils to avoid repeating code. This also helps integrating downstream if someone wants to create a backend themselves etc. 

WIP: can't test kernel_agent as its meta internal?