### PR TITLE
WIP: custom serialization

### DIFF
--- a/BackendBench/suite/base.py
+++ b/BackendBench/suite/base.py
@@ -27,7 +27,7 @@ class OpTest:
         self.op = op
         self.correctness_tests = correctness_tests
         self.performance_tests = performance_tests
-    
+
     def __getstate__(self):
         # Custom serialization to handle callable op
         state = self.__dict__.copy()


### PR DESCRIPTION
Should be very much non-intrusive and shouldn't matter for any current stuff. I.e. when working with modal/multi-process etc, op is a PyCapsule object as it encapsulates the underlying method, which is not serializable. This just breaks it into a module + op_name and reimports when deserialized.