### PR TITLE
Fix geneated kernel file got overwritten

### DIFF
--- a/BackendBench/backends/llm.py
+++ b/BackendBench/backends/llm.py
@@ -137,17 +137,17 @@ You can inspect these files to debug kernel generation, manually test implementa
         os.makedirs(op_dir, exist_ok=True)
         return os.path.join(op_dir, f"{op_name}_implementation_v{attempt}.py")
 
-    def _make_error_func(error_msg):
+    def _make_error_func(self, error_msg):
         def error_func(*args, **kwargs):
             raise RuntimeError(f"Compilation of kernel failed: {error_msg}")
 
         return error_func
 
-    def add_kernel(self, op, kernel_code: str, op_name: str):
+    def add_kernel(self, op, kernel_code: str, op_name: str, attempt: int):
         """Add a kernel implementation for a specific operator."""
 
         try:
-            compiled_kernel = self.compile_kernel_from_string(kernel_code, op_name, attempt=1)
+            compiled_kernel = self.compile_kernel_from_string(kernel_code, op_name, attempt=attempt)
             self.compiled_kernels[op] = compiled_kernel
         except Exception as e:
             self.compiled_kernels[op] = self._make_error_func(str(e))
@@ -317,7 +317,7 @@ You can inspect these files to debug kernel generation, manually test implementa
                 max_attempts=max_attempts,
                 feedback_callback=feedback_callback,
             )
-            self.add_kernel(op, kernel_code, op_name)
+            self.add_kernel(op, kernel_code, op_name, attempts_used)
             if success:
                 logging.info(
                     f"✓ Successfully generated and compiled kernel for {op_name} after {attempts_used} attempts"


### PR DESCRIPTION
Summary:
When using the LLM backend, the initial generated kernel was always overwritten because the add_kernel() function had a hardcoded attempt=1. This PR resolves the issue by passing the actual attempt value to add_kernel().

Additionally, there are inefficiencies in the current workflow (e.g., a kernel code may be stored and compiled multiple times). We should consider some cleanup to reduce technical debt.

Test Plan:
```
python -m BackendBench.scripts.main --suite opinfo --ops addmm --backend llm-relay  > ~/1.txt 2>&1
```

Check the first and the last generated file. They should be different.  
