### PR TITLE
Refactor LLM backend to allow for performance based retries

### DIFF
--- a/BackendBench/eval.py
+++ b/BackendBench/eval.py
@@ -194,7 +194,7 @@ def eval_performance(op, impl, tests) -> Tuple[float, List[PerformanceTestResult
                 PerformanceTestResult(
                     op_name=op.__name__,
                     args=args_str,
-                    speedup=test_time / base_time,
+                    speedup=base_time / test_time,
                     successfully_ran=True,
                     benchmark_time_ms=test_time,
                     reference_time_ms=base_time,

--- a/BackendBench/kernel_templates.py
+++ b/BackendBench/kernel_templates.py
@@ -93,7 +93,11 @@ class KernelTemplateManager:
         return self.templates[framework]
 
     def create_prompt(
-        self, op_name: str, op_signature: str, op_description: str, framework: str = "triton"
+        self,
+        op_name: str,
+        op_signature: str,
+        op_description: str,
+        framework: str = "triton",
     ) -> str:
         """Create a prompt using the specified template."""
         template = self.get_template(framework)
@@ -115,7 +119,7 @@ class KernelTemplateManager:
 
 {base_prompt}
 
-Fix the above errors and generate corrected code."""
+Use the above feedback and generate improved code."""
         else:
             # Fallback if no feedback
             refinement_prompt = f"""{base_prompt}

--- a/BackendBench/llm_client.py
+++ b/BackendBench/llm_client.py
@@ -31,7 +31,9 @@ class LLMKernelGenerator:
             raise ValueError(
                 "ANTHROPIC_API_KEY must be set in environment or passed to constructor"
             )
-        assert "claude" in self.model, "Only Claude (Anthropic) models are supported for now"
+        assert (
+            "claude" in self.model
+        ), "Only Claude (Anthropic) models are supported for now"
 
         self.client = anthropic.Anthropic(api_key=self.api_key)
         # check connection to the server
@@ -113,75 +115,6 @@ export ANTHROPIC_API_KEY=your_api_key_here
         except Exception as e:
             raise RuntimeError(f"Failed to generate kernel for {op_name}: {str(e)}")
 
-    def generate_kernel_with_retry(
-        self,
-        op_name: str,
-        op_signature: str,
-        op_description: str,
-        framework: str = "triton",
-        max_attempts: int = 5,
-        feedback_callback: Optional[Callable] = None,
-    ) -> tuple[str, int, bool]:
-        """Generate kernel with iterative refinement based on feedback.
-
-        Returns:
-            tuple: (final_kernel_code, attempts_used, success)
-        """
-        feedback = None
-        kernel_code = ""  # Initialize to avoid unbound variable error
-
-        for attempt in range(max_attempts):
-            print(f"  Attempt {attempt + 1}/{max_attempts}")
-
-            try:
-                kernel_code = self.generate_kernel(
-                    op_name, op_signature, op_description, framework, feedback
-                )
-            except Exception as e:
-                print(f"  ✗ Failed to generate kernel: {e}")
-                kernel_code = ""
-
-            if feedback_callback is None:
-                return kernel_code, 1, True
-
-            is_correct, feedback_info = feedback_callback(kernel_code, attempt + 1)
-
-            if is_correct:
-                print(f"  ✓ Kernel correct on attempt {attempt + 1}")
-                return kernel_code, attempt + 1, True
-            else:
-                print(
-                    f"  ✗ Kernel failed on attempt {attempt + 1}: {feedback_info.get('summary', 'Unknown error')}"
-                )
-                feedback = self._format_feedback(feedback_info)
-                print(f"  📝 Formatted feedback length: {len(feedback)} chars")
-                if len(feedback) < 100:
-                    print(f"  📝 Short feedback: {repr(feedback)}")
-
-        print(f"  ✗ Failed to generate correct kernel after {max_attempts} attempts")
-        return kernel_code, max_attempts, False
-
-    def _format_feedback(self, feedback_info: Dict) -> str:
-        """Format feedback information for the LLM."""
-        feedback_parts = ["PREVIOUS ATTEMPT FAILED - Please fix the following issues:\n"]
-
-        if feedback_info.get("compilation_error"):
-            feedback_parts.append(f"COMPILATION ERROR:\n{feedback_info['compilation_error']}\n")
-
-        if feedback_info.get("test_errors"):
-            feedback_parts.append("TEST ERRORS:")
-            for i, error in enumerate(feedback_info["test_errors"]):
-                feedback_parts.append(f"\nTest Case {i + 1}:")
-                feedback_parts.append(f"Input: {error['test_input']}")
-                feedback_parts.append(f"Error: {error['error']}")
-                feedback_parts.append(f"Full traceback:\n{error['traceback']}")
-
-        feedback_parts.append(
-            "\nPlease analyze the errors above and generate a corrected version of the kernel."
-        )
-
-        return "\n".join(feedback_parts)
-
     def _extract_code_from_response(self, response: str) -> str:
         if "```python" not in response:
             raise ValueError(
@@ -215,9 +148,13 @@ class LLMRelayKernelGenerator(LLMKernelGenerator):
         try:
             requests.get(f"{self.server_url}/", timeout=5)
         except requests.exceptions.ConnectionError:
-            raise ConnectionError(f"Cannot connect to LLM relay server at {self.server_url}. ")
+            raise ConnectionError(
+                f"Cannot connect to LLM relay server at {self.server_url}. "
+            )
         except requests.exceptions.Timeout:
-            raise TimeoutError(f"Timeout connecting to LLM relay server at {self.server_url}. ")
+            raise TimeoutError(
+                f"Timeout connecting to LLM relay server at {self.server_url}. "
+            )
 
     @property
     def readme_server_description(self) -> str:
@@ -258,7 +195,9 @@ buck run @//mode/inplace run_plugboard_server -- --model gcp-claude-4-sonnet --p
         )
 
         if response.status_code != 200:
-            raise RuntimeError(f"Server returned status {response.status_code}: {response.text}")
+            raise RuntimeError(
+                f"Server returned status {response.status_code}: {response.text}"
+            )
 
         response_data = response.json()
         content = response_data.get("output", "")

--- a/BackendBench/llm_client.py
+++ b/BackendBench/llm_client.py
@@ -5,7 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 import os
-from typing import Callable, Dict, Optional
+from typing import Optional
 
 import anthropic
 import requests
@@ -31,9 +31,7 @@ class LLMKernelGenerator:
             raise ValueError(
                 "ANTHROPIC_API_KEY must be set in environment or passed to constructor"
             )
-        assert (
-            "claude" in self.model
-        ), "Only Claude (Anthropic) models are supported for now"
+        assert "claude" in self.model, "Only Claude (Anthropic) models are supported for now"
 
         self.client = anthropic.Anthropic(api_key=self.api_key)
         # check connection to the server
@@ -148,13 +146,9 @@ class LLMRelayKernelGenerator(LLMKernelGenerator):
         try:
             requests.get(f"{self.server_url}/", timeout=5)
         except requests.exceptions.ConnectionError:
-            raise ConnectionError(
-                f"Cannot connect to LLM relay server at {self.server_url}. "
-            )
+            raise ConnectionError(f"Cannot connect to LLM relay server at {self.server_url}. ")
         except requests.exceptions.Timeout:
-            raise TimeoutError(
-                f"Timeout connecting to LLM relay server at {self.server_url}. "
-            )
+            raise TimeoutError(f"Timeout connecting to LLM relay server at {self.server_url}. ")
 
     @property
     def readme_server_description(self) -> str:
@@ -195,9 +189,7 @@ buck run @//mode/inplace run_plugboard_server -- --model gcp-claude-4-sonnet --p
         )
 
         if response.status_code != 200:
-            raise RuntimeError(
-                f"Server returned status {response.status_code}: {response.text}"
-            )
+            raise RuntimeError(f"Server returned status {response.status_code}: {response.text}")
 
         response_data = response.json()
         content = response_data.get("output", "")

--- a/BackendBench/multiprocessing_eval.py
+++ b/BackendBench/multiprocessing_eval.py
@@ -331,7 +331,6 @@ class MultiprocessingEvaluator:
             try:
                 # Get result from queue
                 result = self.result_queue.get(block=False)
-                logger.info(f"Result obtained: {result}")
 
                 if isinstance(result, ProcessDeathSignal):
                     self.completed_tasks += 1

--- a/test/test_llm_backend.py
+++ b/test/test_llm_backend.py
@@ -9,13 +9,8 @@ import os
 import torch
 
 from BackendBench.backends import LLMBackend
-from BackendBench.llm_client import (
-    KernelTemplateManager,
-    LLMKernelGenerator,
-)
-from BackendBench.suite import (
-    OpInfoTestSuite,
-)
+from BackendBench.llm_client import KernelTemplateManager, LLMKernelGenerator
+from BackendBench.suite import OpInfoTestSuite
 
 
 class MockLLMKernelGenerator(LLMKernelGenerator):
@@ -36,7 +31,9 @@ class MockLLMKernelGenerator(LLMKernelGenerator):
         )
         self.attempts += 1
 
-        file_path = os.path.join(os.path.dirname(__file__), "fixtures", "llm_response", file)
+        file_path = os.path.join(
+            os.path.dirname(__file__), "fixtures", "llm_response", file
+        )
         with open(file_path, "r") as f:
             return f.read()
 
@@ -51,13 +48,13 @@ class TestLLMBackend:
 
     def test_generate_kernels_good(self):
         mock_response_files = ["add_good.txt"]
-        max_attempts = 5
+        attempts = 5
 
         backend = LLMBackend(
             model="mock_model",
             llm_client=MockLLMKernelGenerator(mock_response_files),
         )
-        backend.generate_kernels(self.suite, max_attempts)
+        backend.generate_kernels(self.suite, attempts)
 
         summary_file = os.path.join(backend.kernels_dir, "add", "add_summary.txt")
         assert os.path.exists(summary_file)
@@ -65,17 +62,17 @@ class TestLLMBackend:
         with open(summary_file, "r") as f:
             summary = f.read()
             assert "Final Status: ✓ Success" in summary
-            assert f"Attempts used: 1/{max_attempts}" in summary
+            assert f"Attempts used: 1/{attempts}" in summary
 
     def test_retry(self):
         mock_response_files = ["add_missing_target_functions.txt", "add_good.txt"]
-        max_attempts = 5
+        attempts = 5
 
         backend = LLMBackend(
             model="mock_model",
             llm_client=MockLLMKernelGenerator(mock_response_files),
         )
-        backend.generate_kernels(self.suite, max_attempts)
+        backend.generate_kernels(self.suite, attempts)
 
         summary_file = os.path.join(backend.kernels_dir, "add", "add_summary.txt")
         assert os.path.exists(summary_file)
@@ -83,17 +80,17 @@ class TestLLMBackend:
         with open(summary_file, "r") as f:
             summary = f.read()
             assert "Final Status: ✓ Success" in summary
-            assert f"Attempts used: 2/{max_attempts}" in summary
+            assert f"Attempts used: 2/{attempts}" in summary
 
     def test_missing_target_functions(self):
         mock_response_files = ["add_missing_target_functions.txt"]
-        max_attempts = 1
+        attempts = 1
 
         backend = LLMBackend(
             model="mock_model",
             llm_client=MockLLMKernelGenerator(mock_response_files),
         )
-        backend.generate_kernels(self.suite, max_attempts)
+        backend.generate_kernels(self.suite, attempts)
 
         summary_file = os.path.join(backend.kernels_dir, "add", "add_summary.txt")
         assert os.path.exists(summary_file)
@@ -101,17 +98,17 @@ class TestLLMBackend:
         with open(summary_file, "r") as f:
             summary = f.read()
             assert "Final Status: ✗ Failure" in summary
-            assert f"Attempts used: 1/{max_attempts}" in summary
+            assert f"Attempts used: 1/{attempts}" in summary
 
     def test_missing_python_code_block(self):
         mock_response_files = ["add_missing_python_code_block.txt"]
-        max_attempts = 1
+        attempts = 1
 
         backend = LLMBackend(
             model="mock_model",
             llm_client=MockLLMKernelGenerator(mock_response_files),
         )
-        backend.generate_kernels(self.suite, max_attempts)
+        backend.generate_kernels(self.suite, attempts)
 
         summary_file = os.path.join(backend.kernels_dir, "add", "add_summary.txt")
         assert os.path.exists(summary_file)
@@ -119,4 +116,4 @@ class TestLLMBackend:
         with open(summary_file, "r") as f:
             summary = f.read()
             assert "Final Status: ✗ Failure" in summary
-            assert f"Attempts used: 1/{max_attempts}" in summary
+            assert f"Attempts used: 1/{attempts}" in summary


### PR DESCRIPTION
The goal of this PR is mostly to 1) update the llm agent to instead of stopping at the first attempt to try and improve the performance of the kernel it generates and 2) refactoring to make the implementation of 1 more clean.

## Updating the agent

To cover the enablement of performance based feedback we do the following.
1. Get rid of max_attempts and instead have the agent keep looping improving the kernel until all attempts are used. Even if we're just looking for correctness, it is useful to generate multiple kernels and compare correct ones / it should be a relatively low cost to. (I'm pretty ambivalent on stopping early on correctness only tests, so happy to stop early if there are no performance tests)
2. Incorporate performance feedback when performance tests are present.
3. Now instead of returning the most recent kernel. We now return the most correct kernel produced (as we primarily care about correctness) defined by passing the most tests. For tie breaking we look at average speedup on the performance tests.
4. We log all of the feedback produced for each kernel generated for reference.
5. Added a unit test for this logic
6. Fixed a bug where we calculated speedup incorrectly

## Refactors
1. We introduce a `FeedbackInfo` dataclass to encapsulate compilation errors, correctness and performance results, and provide formatted feedback for LLM consumption.  The reason for this is that we can later subclass this, and experiment with various forms of feedback and a methodical way. Also there's a lot of logic related to evaluating the correctness and formatting feedback. This condenses that logic into the dataclass.
2. We need to keep track of state in order to return the best attempt. It will get unwieldily to pass state between the backend and the llm client. The llm client should just act as a way to access various llm apis / run them without state. Therefore, we move `generate_kernel_with_retry` to the llm backend as it cares about this state. We also rename it to `_kernel_feedback_loop`.

## Results
After running `uv run python BackendBench/scripts/main.py   --suite torchbench   --topn 5 --backend llm-relay   --ops "add,bmm"   --llm-attempts 10`

I get [these results](https://drive.google.com/file/d/1rqphVAkljUOl_oLzjkW6YCg7egzvXzM-/view?usp=sharing). Comment if you need access with your email or dm me as sharing this is a bit weird.

## Testing
Tested this using op_info and it seems to work as expected. The new file structure is as follows.
```bash
uv run python BackendBench/scripts/main.py   --suite torchbench   --topn 5 --backend llm-relay   --ops "add,bmm"   --llm-attempts 10
```
produces
```bash
sahanp@devgpu011 ~/r/BackendBench (performance_feedback)> tree /home/sahanp/repos/BackendBench/generated_kernels
/llm_run_20250917_152207
/home/sahanp/repos/BackendBench/generated_kernels/llm_run_20250917_152207
├── add
│   ├── add_implementation_v10_generated_feedback.txt
│   ├── add_implementation_v10.py
│   ├── add_implementation_v1_generated_feedback.txt
│   ├── add_implementation_v1.py
│   ├── add_implementation_v2_generated_feedback.txt
│   ├── add_implementation_v2.py
│   ├── add_implementation_v3_generated_feedback.txt
│   ├── add_implementation_v3.py
│   ├── add_implementation_v4_generated_feedback.txt
│   ├── add_implementation_v4.py
│   ├── add_implementation_v5_generated_feedback.txt
│   ├── add_implementation_v5.py
│   ├── add_implementation_v6_generated_feedback.txt
│   ├── add_implementation_v6.py
│   ├── add_implementation_v7_generated_feedback.txt
│   ├── add_implementation_v7.py
│   ├── add_implementation_v8_generated_feedback.txt
│   ├── add_implementation_v8.py
│   ├── add_implementation_v9_generated_feedback.txt
│   ├── add_implementation_v9.py
│   ├── add_kernel_gen_summary.json
│   ├── add_summary.txt
│   └── __pycache__
│       ├── add_implementation_v10.cpython-313.pyc
│       ├── add_implementation_v1.cpython-313.pyc
│       ├── add_implementation_v2.cpython-313.pyc
│       ├── add_implementation_v3.cpython-313.pyc
│       ├── add_implementation_v4.cpython-313.pyc
│       ├── add_implementation_v5.cpython-313.pyc
│       ├── add_implementation_v6.cpython-313.pyc
│       ├── add_implementation_v7.cpython-313.pyc
│       ├── add_implementation_v8.cpython-313.pyc
│       └── add_implementation_v9.cpython-313.pyc
├── add_
│   ├── add__implementation_v10_generated_feedback.txt
│   ├── add__implementation_v10.py
│   ├── add__implementation_v1_generated_feedback.txt
│   ├── add__implementation_v1.py
│   ├── add__implementation_v2_generated_feedback.txt
│   ├── add__implementation_v2.py
│   ├── add__implementation_v3_generated_feedback.txt
│   ├── add__implementation_v3.py
│   ├── add__implementation_v4_generated_feedback.txt
│   ├── add__implementation_v4.py
│   ├── add__implementation_v5_generated_feedback.txt
│   ├── add__implementation_v5.py
│   ├── add__implementation_v6_generated_feedback.txt
│   ├── add__implementation_v6.py
│   ├── add__implementation_v7_generated_feedback.txt
│   ├── add__implementation_v7.py
│   ├── add__implementation_v8_generated_feedback.txt
│   ├── add__implementation_v8.py
│   ├── add__implementation_v9_generated_feedback.txt
│   ├── add__implementation_v9.py
│   ├── add__kernel_gen_summary.json
│   ├── add__summary.txt
│   └── __pycache__
│       ├── add__implementation_v10.cpython-313.pyc
│       ├── add__implementation_v1.cpython-313.pyc
│       ├── add__implementation_v2.cpython-313.pyc
│       ├── add__implementation_v3.cpython-313.pyc
│       ├── add__implementation_v4.cpython-313.pyc
│       ├── add__implementation_v5.cpython-313.pyc
│       ├── add__implementation_v6.cpython-313.pyc
│       ├── add__implementation_v7.cpython-313.pyc
│       ├── add__implementation_v8.cpython-313.pyc
│       └── add__implementation_v9.cpython-313.pyc
├── addcmul
│   ├── addcmul_implementation_v10_generated_feedback.txt
│   ├── addcmul_implementation_v10.py
│   ├── addcmul_implementation_v1_generated_feedback.txt
│   ├── addcmul_implementation_v1.py
│   ├── addcmul_implementation_v2_generated_feedback.txt
│   ├── addcmul_implementation_v2.py
│   ├── addcmul_implementation_v3_generated_feedback.txt
│   ├── addcmul_implementation_v3.py
│   ├── addcmul_implementation_v4_generated_feedback.txt
│   ├── addcmul_implementation_v4.py
│   ├── addcmul_implementation_v5_generated_feedback.txt
│   ├── addcmul_implementation_v5.py
│   ├── addcmul_implementation_v6_generated_feedback.txt
│   ├── addcmul_implementation_v6.py
│   ├── addcmul_implementation_v7_generated_feedback.txt
│   ├── addcmul_implementation_v7.py
│   ├── addcmul_implementation_v8_generated_feedback.txt
│   ├── addcmul_implementation_v8.py
│   ├── addcmul_implementation_v9_generated_feedback.txt
│   ├── addcmul_implementation_v9.py
│   ├── addcmul_kernel_gen_summary.json
│   ├── addcmul_summary.txt
│   └── __pycache__
│       ├── addcmul_implementation_v10.cpython-313.pyc
│       ├── addcmul_implementation_v1.cpython-313.pyc
│       ├── addcmul_implementation_v2.cpython-313.pyc
│       ├── addcmul_implementation_v3.cpython-313.pyc
│       ├── addcmul_implementation_v4.cpython-313.pyc
│       ├── addcmul_implementation_v5.cpython-313.pyc
│       ├── addcmul_implementation_v6.cpython-313.pyc
│       ├── addcmul_implementation_v7.cpython-313.pyc
│       ├── addcmul_implementation_v8.cpython-313.pyc
│       └── addcmul_implementation_v9.cpython-313.pyc
├── addmm
│   ├── addmm_implementation_v10_generated_feedback.txt
│   ├── addmm_implementation_v10.py
│   ├── addmm_implementation_v1_generated_feedback.txt
│   ├── addmm_implementation_v1.py
│   ├── addmm_implementation_v2_generated_feedback.txt
│   ├── addmm_implementation_v2.py
│   ├── addmm_implementation_v3_generated_feedback.txt
│   ├── addmm_implementation_v3.py
│   ├── addmm_implementation_v4_generated_feedback.txt
│   ├── addmm_implementation_v4.py
│   ├── addmm_implementation_v5_generated_feedback.txt
│   ├── addmm_implementation_v5.py
│   ├── addmm_implementation_v6_generated_feedback.txt
│   ├── addmm_implementation_v6.py
│   ├── addmm_implementation_v7_generated_feedback.txt
│   ├── addmm_implementation_v7.py
│   ├── addmm_implementation_v8_generated_feedback.txt
│   ├── addmm_implementation_v8.py
│   ├── addmm_implementation_v9_generated_feedback.txt
│   ├── addmm_implementation_v9.py
│   ├── addmm_kernel_gen_summary.json
│   ├── addmm_summary.txt
│   └── __pycache__
│       ├── addmm_implementation_v10.cpython-313.pyc
│       ├── addmm_implementation_v1.cpython-313.pyc
│       ├── addmm_implementation_v2.cpython-313.pyc
│       ├── addmm_implementation_v3.cpython-313.pyc
│       ├── addmm_implementation_v4.cpython-313.pyc
│       ├── addmm_implementation_v5.cpython-313.pyc
│       ├── addmm_implementation_v6.cpython-313.pyc
│       ├── addmm_implementation_v7.cpython-313.pyc
│       ├── addmm_implementation_v8.cpython-313.pyc
│       └── addmm_implementation_v9.cpython-313.pyc
├── bmm
│   ├── bmm_implementation_v10_generated_feedback.txt
│   ├── bmm_implementation_v10.py
│   ├── bmm_implementation_v1_generated_feedback.txt
│   ├── bmm_implementation_v1.py
│   ├── bmm_implementation_v2_generated_feedback.txt
│   ├── bmm_implementation_v2.py
│   ├── bmm_implementation_v3_generated_feedback.txt
│   ├── bmm_implementation_v3.py
│   ├── bmm_implementation_v4_generated_feedback.txt
│   ├── bmm_implementation_v4.py
│   ├── bmm_implementation_v5_generated_feedback.txt
│   ├── bmm_implementation_v5.py
│   ├── bmm_implementation_v6_generated_feedback.txt
│   ├── bmm_implementation_v6.py
│   ├── bmm_implementation_v7_generated_feedback.txt
│   ├── bmm_implementation_v7.py
│   ├── bmm_implementation_v8_generated_feedback.txt
│   ├── bmm_implementation_v8.py
│   ├── bmm_implementation_v9_generated_feedback.txt
│   ├── bmm_implementation_v9.py
│   ├── bmm_kernel_gen_summary.json
│   ├── bmm_summary.txt
│   └── __pycache__
│       ├── bmm_implementation_v10.cpython-313.pyc
│       ├── bmm_implementation_v1.cpython-313.pyc
│       ├── bmm_implementation_v2.cpython-313.pyc
│       ├── bmm_implementation_v3.cpython-313.pyc
│       ├── bmm_implementation_v4.cpython-313.pyc
│       ├── bmm_implementation_v5.cpython-313.pyc
│       ├── bmm_implementation_v6.cpython-313.pyc
│       ├── bmm_implementation_v7.cpython-313.pyc
│       ├── bmm_implementation_v8.cpython-313.pyc
│       └── bmm_implementation_v9.cpython-313.pyc
├── OVERALL_SUMMARY.txt
└── README.md

10 directories, 162 files
```

I think `addmm` showcases what this looks like in practice. Generally, the llm does not always improve (we may need to improve the prompt). However, a trace of kernels looks a bit like this (from `addcmul_kernel_gen_summary.json`)

```bash
[
    {
        "attempt": 1,
        "kernel_file": "generated_kernels/llm_run_20250917_152207/addmm/addmm_implementation_v1.py",
        "compilation_error": null,
        "overall_speedup": 0.27065104246139526,
        "correctness_score": 1.0,
        "is_correct": true
    },
    {
        "attempt": 2,
        "kernel_file": "generated_kernels/llm_run_20250917_152207/addmm/addmm_implementation_v2.py",
        "compilation_error": null,
        "overall_speedup": 0.2721068263053894,
        "correctness_score": 1.0,
        "is_correct": true
    },
    {
        "attempt": 3,
        "kernel_file": "generated_kernels/llm_run_20250917_152207/addmm/addmm_implementation_v3.py",
        "compilation_error": null,
        "overall_speedup": 0.28095293045043945,
        "correctness_score": 1.0,
        "is_correct": true
    },
    {
        "attempt": 4,
        "kernel_file": "generated_kernels/llm_run_20250917_152207/addmm/addmm_implementation_v4.py",
        "compilation_error": null,
        "overall_speedup": 0.19436556100845337,
        "correctness_score": 1.0,
        "is_correct": true
    },
    {
        "attempt": 5,
        "kernel_file": "generated_kernels/llm_run_20250917_152207/addmm/addmm_implementation_v5.py",
        "compilation_error": null,
        "overall_speedup": 0.4371911883354187,
        "correctness_score": 1.0,
        "is_correct": true
    },
    {
        "attempt": 6,
        "kernel_file": "generated_kernels/llm_run_20250917_152207/addmm/addmm_implementation_v6.py",
        "compilation_error": null,
        "overall_speedup": 0.39197951555252075,
        "correctness_score": 1.0,
        "is_correct": true
    },
    {
        "attempt": 7,
        "kernel_file": "generated_kernels/llm_run_20250917_152207/addmm/addmm_implementation_v7.py",
        "compilation_error": null,
        "overall_speedup": 0.42599180340766907,
        "correctness_score": 1.0,
        "is_correct": true
    },
    {
        "attempt": 8,
        "kernel_file": "generated_kernels/llm_run_20250917_152207/addmm/addmm_implementation_v8.py",
        "compilation_error": null,
        "overall_speedup": 0.3805958032608032,
        "correctness_score": 1.0,
        "is_correct": true
    },
    {
        "attempt": 9,
        "kernel_file": "generated_kernels/llm_run_20250917_152207/addmm/addmm_implementation_v9.py",
        "compilation_error": null,
        "overall_speedup": 0.5098515748977661,
        "correctness_score": 1.0,
        "is_correct": true
    },
    {
        "attempt": 10,
        "kernel_file": "generated_kernels/llm_run_20250917_152207/addmm/addmm_implementation_v10.py",
        "compilation_error": null,
        "overall_speedup": 0.5410254001617432,
        "correctness_score": 1.0,
        "is_correct": true
    }
]```

Below is the best kernel (10) and the first kernel 
`addmm_implementation_v1.py`
```python
import torch
import triton
import triton.language as tl

@triton.jit
def addmm_triton_kernel(
    bias_ptr, a_ptr, b_ptr, output_ptr,
    M, N, K,
    stride_bias,
    stride_am, stride_ak,
    stride_bk, stride_bn,
    stride_om, stride_on,
    alpha: tl.constexpr,
    beta: tl.constexpr,
    BLOCK_SIZE_M: tl.constexpr,
    BLOCK_SIZE_N: tl.constexpr,
    BLOCK_SIZE_K: tl.constexpr,
):
    # Get program IDs
    pid_m = tl.program_id(0)
    pid_n = tl.program_id(1)
    
    # Compute offsets
    offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
    offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
    offs_k = tl.arange(0, BLOCK_SIZE_K)
    
    # Initialize accumulator
    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
    
    # Matrix multiplication loop
    for k in range(0, K, BLOCK_SIZE_K):
        # Load A block
        a_ptrs = a_ptr + (offs_m[:, None] * stride_am + (k + offs_k[None, :]) * stride_ak)
        a_mask = (offs_m[:, None] < M) & ((k + offs_k[None, :]) < K)
        a = tl.load(a_ptrs, mask=a_mask, other=0.0)
        
        # Load B block
        b_ptrs = b_ptr + ((k + offs_k[:, None]) * stride_bk + offs_n[None, :] * stride_bn)
        b_mask = ((k + offs_k[:, None]) < K) & (offs_n[None, :] < N)
        b = tl.load(b_ptrs, mask=b_mask, other=0.0)
        
        # Accumulate
        accumulator += tl.dot(a, b)
    
    # Load bias
    bias_ptrs = bias_ptr + offs_n * stride_bias
    bias_mask = offs_n < N
    bias = tl.load(bias_ptrs, mask=bias_mask, other=0.0)
    
    # Apply alpha and beta scaling, add bias
    result = alpha * accumulator + beta * bias[None, :]
    
    # Store result
    output_ptrs = output_ptr + (offs_m[:, None] * stride_om + offs_n[None, :] * stride_on)
    output_mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
    tl.store(output_ptrs, result, mask=output_mask)

def addmm_kernel_impl(*args, **kwargs):
    # Parse arguments - addmm(bias, mat1, mat2, *, beta=1, alpha=1)
    if len(args) >= 3:
        bias, mat1, mat2 = args[0], args[1], args[2]
    else:
        raise ValueError("addmm requires at least 3 arguments: bias, mat1, mat2")
    
    # Get alpha and beta from kwargs or use defaults
    alpha = kwargs.get('alpha', 1.0)
    beta = kwargs.get('beta', 1.0)
    
    # Store original devices
    bias_device = bias.device
    mat1_device = mat1.device
    mat2_device = mat2.device
    
    # Check if any tensor is on GPU and CUDA is not available
    devices = [bias_device, mat1_device, mat2_device]
    has_cuda_tensor = any(d.type == 'cuda' for d in devices)
    
    if has_cuda_tensor and not torch.cuda.is_available():
        raise RuntimeError("CUDA tensors provided but CUDA is not available")
    
    # Move tensors to GPU if needed
    if torch.cuda.is_available():
        bias_gpu = bias.cuda() if bias_device.type == 'cpu' else bias
        mat1_gpu = mat1.cuda() if mat1_device.type == 'cpu' else mat1
        mat2_gpu = mat2.cuda() if mat2_device.type == 'cpu' else mat2
    else:
        # All tensors should be on CPU
        bias_gpu = bias.cpu()
        mat1_gpu = mat1.cpu()
        mat2_gpu = mat2.cpu()
    
    # Ensure tensors are contiguous
    bias_gpu = bias_gpu.contiguous()
    mat1_gpu = mat1_gpu.contiguous()
    mat2_gpu = mat2_gpu.contiguous()
    
    # Get dimensions
    M, K = mat1_gpu.shape
    K2, N = mat2_gpu.shape
    
    if K != K2:
        raise RuntimeError(f"mat1 and mat2 shapes cannot be multiplied ({M}x{K} and {K2}x{N})")
    
    # Check bias shape
    if bias_gpu.numel() == 1:
        # Scalar bias - broadcast to (N,)
        bias_gpu = bias_gpu.expand(N).contiguous()
    elif bias_gpu.shape == (N,):
        # Vector bias - already correct shape
        pass
    elif bias_gpu.shape == (1, N):
        # Row vector - reshape to (N,)
        bias_gpu = bias_gpu.view(N).contiguous()
    else:
        raise RuntimeError(f"bias shape {bias_gpu.shape} is not compatible with output shape ({M}, {N})")
    
    # Create output tensor on GPU
    output_gpu = torch.empty((M, N), dtype=mat1_gpu.dtype, device=mat1_gpu.device)
    
    # Define block sizes
    BLOCK_SIZE_M = 64
    BLOCK_SIZE_N = 64
    BLOCK_SIZE_K = 32
    
    # Compute grid
    grid = (
        triton.cdiv(M, BLOCK_SIZE_M),
        triton.cdiv(N, BLOCK_SIZE_N),
    )
    
    # Launch kernel
    addmm_triton_kernel[grid](
        bias_gpu, mat1_gpu, mat2_gpu, output_gpu,
        M, N, K,
        bias_gpu.stride(0),
        mat1_gpu.stride(0), mat1_gpu.stride(1),
        mat2_gpu.stride(0), mat2_gpu.stride(1),
        output_gpu.stride(0), output_gpu.stride(1),
        alpha=float(alpha),
        beta=float(beta),
        BLOCK_SIZE_M=BLOCK_SIZE_M,
        BLOCK_SIZE_N=BLOCK_SIZE_N,
        BLOCK_SIZE_K=BLOCK_SIZE_K,
    )
    
    # Determine output device (same as first input tensor's original device)
    output_device = bias_device
    
    # Move result back to original device if needed
    if output_device.type == 'cpu' and output_gpu.device.type == 'cuda':
        output = output_gpu.cpu()
    else:
        output = output_gpu
    
    return output
```

`addmm_implementation_v10.py`
```python
import torch
import triton
import triton.language as tl

@triton.autotune(
    configs=[
        # Optimized configs based on performance analysis
        # Large matrix configs - prioritize memory bandwidth
        triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 64}, num_stages=3, num_warps=8),
        triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 256, 'BLOCK_SIZE_K': 64}, num_stages=3, num_warps=8),
        triton.Config({'BLOCK_SIZE_M': 256, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 64}, num_stages=3, num_warps=8),
        
        # High K dimension configs - optimize for memory reuse
        triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 128}, num_stages=2, num_warps=8),
        triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 128}, num_stages=2, num_warps=8),
        
        # Balanced configs for medium matrices
        triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 64}, num_stages=4, num_warps=4),
        triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 32}, num_stages=4, num_warps=4),
        
        # Small matrix configs
        triton.Config({'BLOCK_SIZE_M': 32, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 32}, num_stages=5, num_warps=2),
        triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 32, 'BLOCK_SIZE_K': 32}, num_stages=5, num_warps=2),
        
        # Very large matrix configs
        triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 256, 'BLOCK_SIZE_K': 32}, num_stages=3, num_warps=8),
        triton.Config({'BLOCK_SIZE_M': 256, 'BLOCK_SIZE_N': 128, 'BLOCK_SIZE_K': 32}, num_stages=3, num_warps=8),
    ],
    key=['M', 'N', 'K'],
)
@triton.jit
def addmm_triton_kernel(
    bias_ptr, a_ptr, b_ptr, output_ptr,
    M, N, K,
    stride_bias,
    stride_am, stride_ak,
    stride_bk, stride_bn,
    stride_om, stride_on,
    alpha: tl.constexpr,
    beta: tl.constexpr,
    BLOCK_SIZE_M: tl.constexpr,
    BLOCK_SIZE_N: tl.constexpr,
    BLOCK_SIZE_K: tl.constexpr,
):
    # Get program IDs
    pid_m = tl.program_id(0)
    pid_n = tl.program_id(1)
    
    # Compute offsets for this block
    offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
    offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
    
    # Pre-compute masks once
    m_mask = offs_m < M
    n_mask = offs_n < N
    
    # Initialize accumulator with higher precision
    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
    
    # Optimized matrix multiplication loop
    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
    for k_tile in range(k_tiles):
        offs_k = k_tile * BLOCK_SIZE_K + tl.arange(0, BLOCK_SIZE_K)
        k_mask = offs_k < K
        
        # Load A block with optimized addressing
        a_ptrs = a_ptr + (offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak)
        a_mask = m_mask[:, None] & k_mask[None, :]
        a = tl.load(a_ptrs, mask=a_mask, other=0.0)
        
        # Load B block with optimized addressing
        b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_n[None, :] * stride_bn)
        b_mask = k_mask[:, None] & n_mask[None, :]
        b = tl.load(b_ptrs, mask=b_mask, other=0.0)
        
        # Accumulate using optimized dot product
        accumulator = tl.dot(a, b, accumulator, allow_tf32=False)
    
    # Load bias once and apply scaling
    bias_ptrs = bias_ptr + offs_n * stride_bias
    bias = tl.load(bias_ptrs, mask=n_mask, other=0.0)
    
    # Apply alpha and beta scaling efficiently
    if alpha != 1.0:
        accumulator = accumulator * alpha
    
    if beta != 1.0:
        bias = bias * beta
    
    # Add bias with broadcasting
    result = accumulator + bias[None, :]
    
    # Store result with proper masking
    output_ptrs = output_ptr + (offs_m[:, None] * stride_om + offs_n[None, :] * stride_on)
    output_mask = m_mask[:, None] & n_mask[None, :]
    tl.store(output_ptrs, result, mask=output_mask)

def addmm_kernel_impl(*args, **kwargs):
    # Parse arguments
    if len(args) >= 3:
        bias, mat1, mat2 = args[0], args[1], args[2]
    else:
        raise ValueError("addmm requires at least 3 arguments: bias, mat1, mat2")
    
    # Get alpha and beta from kwargs
    alpha = kwargs.get('alpha', 1.0)
    beta = kwargs.get('beta', 1.0)
    
    # Store original device
    original_device = bias.device
    
    # Only move to GPU if not already there and CUDA is available
    needs_device_transfer = False
    if torch.cuda.is_available() and bias.device.type != 'cuda':
        bias = bias.cuda()
        mat1 = mat1.cuda()
        mat2 = mat2.cuda()
        needs_device_transfer = True
    
    # Get dimensions
    M, K = mat1.shape
    K2, N = mat2.shape
    
    if K != K2:
        raise RuntimeError(f"mat1 and mat2 shapes cannot be multiplied ({M}x{K} and {K2}x{N})")
    
    # Handle bias shape efficiently
    if bias.numel() == 1:
        bias = bias.expand(N)
    elif bias.shape == (1, N):
        bias = bias.view(N)
    elif bias.shape != (N,):
        raise RuntimeError(f"bias shape {bias.shape} is not compatible with output shape ({M}, {N})")
    
    # Create output tensor with optimal memory layout
    output = torch.empty((M, N), dtype=mat1.dtype, device=mat1.device, memory_format=torch.contiguous_format)
    
    # Ensure tensors are contiguous for optimal memory access
    if not mat1.is_contiguous():
        mat1 = mat1.contiguous()
    if not mat2.is_contiguous():
        mat2 = mat2.contiguous()
    if not bias.is_contiguous():
        bias = bias.contiguous()
    
    # Improved adaptive grid sizing based on matrix characteristics
    total_elements = M * N
    k_ratio = K / max(M, N)
    
    if total_elements < 50000:  # Small matrices
        block_m = min(64, max(16, triton.next_power_of_2(M // 4)))
        block_n = min(64, max(16, triton.next_power_of_2(N // 4)))
    elif k_ratio > 50:  # High K dimension matrices
        block_m = min(128, max(32, triton.next_power_of_2(M // 8)))
        block_n = min(128, max(32, triton.next_power_of_2(N // 8)))
    elif total_elements > 1000000:  # Very large matrices
        block_m = min(256, max(64, triton.next_power_of_2(M // 16)))
        block_n = min(256, max(64, triton.next_power_of_2(N // 16)))
    else:  # Medium matrices
        block_m = min(128, max(32, triton.next_power_of_2(M // 8)))
        block_n = min(128, max(32, triton.next_power_of_2(N // 8)))
    
    grid = (triton.cdiv(M, block_m), triton.cdiv(N, block_n))
    
    # Launch kernel with optimized parameters
    addmm_triton_kernel[grid](
        bias, mat1, mat2, output,
        M, N, K,
        bias.stride(0),
        mat1.stride(0), mat1.stride(1),
        mat2.stride(0), mat2.stride(1),
        output.stride(0), output.stride(1),
        alpha=float(alpha),
        beta=float(beta),
    )
    
    # Move result back to original device only if necessary
    if needs_device_transfer:
        output = output.to(original_device)
    
    return output
```
