### PR TITLE
Fix smoke test

### DIFF
--- a/BackendBench/suite/smoke.py
+++ b/BackendBench/suite/smoke.py
@@ -21,10 +21,14 @@ SmokeTestSuite = TestSuite(
         OpTest(
             get_operator(torch.ops.aten.relu.default),
             [
-                Test(randn(2, device="cpu")),
+                Test(
+                    randn(2, device="cpu"),
+                ),
             ],
             [
-                Test(randn(2**28, device="cpu")),
+                Test(
+                    randn(2**10, 2**10, device="cpu"),
+                ),
             ],
         )
     ],

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ python -m BackendBench.scripts.setup_operator_directories
 3. **Test your implementations**:
 
 ```bash
+# smoke test to make sure everything is in check
+python BackendBench/scripts/main.py --suite smoke --backend aten
+
 # OpInfo correctness tests
 python BackendBench/scripts/main.py --suite opinfo --backend directory
 


### PR DESCRIPTION
As we did not cache arguments there was a bug where the performance test in smoke test always failed (thanks @S1ro1 for catching this). This pr introduces argument caching to our eval so similar things don't happen. Now the output of performance test for smoke looks something like this (speedup is wrong but is fixed upstream in https://github.com/meta-pytorch/BackendBench/pull/166).



output of the the test from `full_results.json` shows it passes now (from `uv run python BackendBench/scripts/main.py   --suite smoke --backend aten`)
```json
[
  {
    "op_name": "relu.default",
    "args": "((T([1024, 1024], f32),), {})",
    "speedup": 0.809378189622815,
    "benchmark_time_ms": 0.00898388202458752,
    "reference_time_ms": 0.011099733276447902,
    "error_msg": "",
    "successfully_ran": true,
    "test_type": "performance"
  },
  {
    "op_name": "relu.default",
    "args": "((T([2], f32),), {})",
    "is_correct": true,
    "error_msg": "",
    "error_type": "",
    "traceback": "",
    "max_abs_error": 0.0,
    "max_rel_error": 0.0,
    "test_type": "correctness"
  }
]
```