### PR TITLE
Fix nested context manager behavior 

### DIFF
--- a/BackendBench/scripts/create_watermarked_operators.py
+++ b/BackendBench/scripts/create_watermarked_operators.py
@@ -32,10 +32,9 @@ def create_watermarked_impl(
     """Generate a watermarked implementation that returns a constant tensor."""
 
     if watermark_value is None:
-        if use_unique_watermarks:
-            watermark_value = get_operator_watermark_value(op_name)
-        else:
-            watermark_value = WATERMARK_BASE
+        watermark_value = WATERMARK_BASE
+    if use_unique_watermarks:
+        watermark_value = get_operator_watermark_value(op_name, watermark_value)
 
     return f'''# Watermarked implementation for {op_name} operator
 # This implementation returns a constant tensor to verify monkey patching


### PR DESCRIPTION
This PR fixes an issue with the nested behavior of the BackendBench context manager.

Previously, the context manager did not correctly restore the environment when used in a nested fashion. The expected behavior is that, upon exiting a nested context, the environment should revert to its previous state, i.e., the state before entering the context.

This PR enables proper nested context management by saving a local lib object within the context manager, rather than registering ops using the global _lib. When the local lib is destructed upon exiting the context, the environment is correctly restored to its previous state.

I have updated the test_context_manager_nested_behavior function to thoroughly test this scenario. The test now registers two kernel directories: one containing relu and another containing leaky_relu, ensuring that the context manager correctly handles nested environments.
