### PR TITLE
Enhanced CuTe DSL Prompting, Bug Fixes, and Improved Operator Correctness

### DIFF
--- a/BackendBench/backends/llm.py
+++ b/BackendBench/backends/llm.py
@@ -81,7 +81,8 @@ class FeedbackInfo:
             return 0.0
 
         # we should always have at least one correctness test
-        assert len(self.correctness_results), "No correctness tests ran for this kernel"
+        if len(self.correctness_results) == 0:
+            return 0.0
 
         return (
             sum(1 for r in self.correctness_results if r.is_correct)

--- a/BackendBench/prompts.py
+++ b/BackendBench/prompts.py
@@ -48,31 +48,55 @@ CUTEDSL_KERNEL_PROMPT = """Generate a CuteDSL kernel for: {op_name}
 Operation: {op_signature}
 {op_description}
 
-Requirements:
-- CuteDSL kernel function MUST be named: {folder_name}_cutedsl_kernel
-- Launcher function MUST be named: {folder_name}_kernel_launch
-- Wrapper function MUST be named: {folder_name}_kernel_impl
-- Use modern CuteDSL syntax with proper grid computation
-- Include all necessary imports (torch, cutlass, cutlass.cute as cute)
+CuTe DSL is a Python-based domain-specific language (DSL) for dynamic compilation of numeric and GPU-oriented code.
 
-The {folder_name}_kernel_impl wrapper function MUST handle complete device management:
+Requirements:
+- The main kernel function MUST be named: {folder_name}_cutedsl_kernel and decorated with @cute.kernel
+- The launcher function MUST be named: {folder_name}_kernel_launch and decorated with @cute.jit
+- The wrapper function MUST be named: {folder_name}_kernel_impl
+- Use correct CuteDSL syntax for grid, block, cluster, and seme computation
+- Include all necessary imports: torch, cutlass, cutlass.cute as cute, and from_dlpack from cutlass.cute.runtime
+- Do NOT use try/except blocks for device management or error handling
+- Do NOT fall back to PyTorch implementations
+- Avoid dynamic tensor creation inside kernel loops
+- Avoid arithmetic on thread/block indices that could cause out-of-bounds errors
+- Handle different tensor and scalar argument types and data types including int and float properly
+- Make sure to match argument data types when necessary (e.g. all float32 or all int 32)
+- Use a higher precision datatype for all intermediate results during computation, and explicitly cast the final output to the output tensor's dtype before assignment.
+- For in-place operations such as leaky_relu_, ensure that the kernel only takes input tensors and writes results directly to the input tensor, without allocating or using a separate output tensor.
+
+
+The {folder_name}_kernel_impl wrapper function MUST:
 - Move CPU tensors to GPU if needed (use .cuda() when torch.cuda.is_available())
 - Raise clear errors if CUDA is not available for GPU tensors
-- Call the CuteDSL kernel with GPU tensors
-- Move results back to original device of input tensors
-- Handle both args and kwargs properly
+- Call the CuteDSL kernel via the launcher with GPU tensors
+- Move results back to the original device of input tensors
+- Handle both positional (args) and keyword (kwargs) arguments properly
 - Preserve original tensor devices and restore them for outputs
-- Avoid falling back to PyTorch implementation
-- Avoid using try except block
+- Flatten tensors for kernel launch and restore original shapes after computation
+- Use custom cache for kernel compilation and reuse across different kernel launches
+- Convert tensors to/from DLPack for kernel launch and restore original shapes after computation
+- Accept cutlass datatypes such as cutlass.Float32, cutlass.Int32
 
-Generate complete, runnable code only - no framework will add device handling wrapper code.
+
+Generate complete, runnable code only – no framework will add device handling wrapper code.
+
+Common errors to avoid:
+- Using try/except for device management
+- Fallback to PyTorch for unsupported cases
+- Dynamic tensor creation inside kernel loops
+- Incorrect grid/block configuration leading to out-of-bounds access
+- Not flattening tensors before kernel launch
+- Not restoring output shape after computation
+- Use python data type in kernel code
+- Use variables defined in dynamic control flow.
 
 Example:
 {example}
 """
 
 CUTEDSL_OPTIMIZATIONS = {
-    "default": "Use efficient memory access patterns and appropriate block sizes."
+    "default": "Use efficient memory access patterns, appropriate block sizes, and avoid dynamic tensor creation inside kernel loops."
 }
 
 CUTEDSL_EXAMPLE_TEMPLATES = {
@@ -81,8 +105,9 @@ import cutlass
 import cutlass.cute as cute
 from cutlass.cute.runtime import from_dlpack
 
+## Example 1: Element-wise add tensor kernel
 @cute.kernel
-def add_tensor_kernel(
+def add__Tensor_kernel(
     gA: cute.Tensor,
     gB: cute.Tensor,
     gC: cute.Tensor,
@@ -93,76 +118,33 @@ def add_tensor_kernel(
 
     thread_idx = bidx * bdim + tidx
 
-    # Map thread index to logical index of input tensor
     total_elements = gA.shape[0]
 
-    # Bounds checking
     if thread_idx < total_elements:
-
-        # Map logical index to physical address via tensor layout
         a_val = gA[thread_idx]
         b_val = gB[thread_idx]
 
-        # Perform element-wise addition
         gC[thread_idx] = a_val + b_val
 
-@cute.kernel
-def add_scalar_kernel(
-    gA: cute.Tensor,
-    gC: cute.Tensor,
-    scalar_val,
-):
-    tidx, _, _ = cute.arch.thread_idx()
-    bidx, _, _ = cute.arch.block_idx()
-    bdim, _, _ = cute.arch.block_dim()
-
-    thread_idx = bidx * bdim + tidx
-
-    # Map thread index to logical index of input tensor
-    total_elements = gA.shape[0]
-
-    # Bounds checking
-    if thread_idx < total_elements:
-
-        # Map logical index to physical address via tensor layout
-        a_val = gA[thread_idx]
-
-        # Perform element-wise addition with scalar
-        gC[thread_idx] = a_val + scalar_val
 
 @cute.jit
-def add_tensor_kernel_launch(
+def add__Tensor_kernel_launch(
     mA: cute.Tensor,
     mB: cute.Tensor,
-    mC: cute.Tensor
-):
-    num_threads_per_block = 1024
-
-    total_elements = mA.shape[0]
-    num_blocks = (total_elements + num_threads_per_block - 1) // num_threads_per_block
-
-    kernel = add_tensor_kernel(mA, mB, mC)
-    kernel.launch(grid=(num_blocks, 1, 1),
-                  block=(num_threads_per_block, 1, 1))
-
-@cute.jit
-def add_scalar_kernel_launch(
-    mA: cute.Tensor,
     mC: cute.Tensor,
-    scalar_val
 ):
     num_threads_per_block = 1024
 
     total_elements = mA.shape[0]
     num_blocks = (total_elements + num_threads_per_block - 1) // num_threads_per_block
 
-    kernel = add_scalar_kernel(mA, mC, scalar_val)
+    kernel = add__Tensor_kernel(mA, mB, mC)
     kernel.launch(grid=(num_blocks, 1, 1),
                   block=(num_threads_per_block, 1, 1))
 
-def add_kernel_impl(*args, **kwargs):
+custom_cache_add__Tensor = {}
 
-    # Handle both positional and keyword arguments
+def add__Tensor_kernel_impl(*args, **kwargs):
     if len(args) >= 2:
         input_tensor = args[0]
         other = args[1]
@@ -173,23 +155,102 @@ def add_kernel_impl(*args, **kwargs):
         input_tensor = kwargs['input']
         other = kwargs['other']
     else:
-        raise ValueError("add requires 'input' and 'other' arguments")
+        raise ValueError("add_ requires 'input' and 'other' arguments")
 
-    if torch.is_tensor(other):
-        input_tensor, other = torch.broadcast_tensors(input_tensor, other)
+    alpha = kwargs.get('alpha', 1)
 
-    if 'alpha' in kwargs:
-        alpha = kwargs['alpha']
+    input_broadcast, other_broadcast = torch.broadcast_tensors(input_tensor, other)
+    if input_broadcast.shape != input_tensor.shape:
+        raise RuntimeError(
+            f"In-place operation cannot expand tensor from shape {input_tensor.shape} "
+            f"to shape {input_broadcast.shape}"
+        )
+    other = other_broadcast
+
+    if alpha != 1:
         other = other * alpha
 
-    # Remember original device
-    original_device = input_tensor.device
+    if not input_tensor.is_contiguous():
+        raise RuntimeError("In-place operation requires contiguous tensor")
 
-    # Flatten all tensors and save their shapes
+    input_flat = input_tensor.view(-1)
+
+    if not input_tensor.is_cuda:
+        if not torch.cuda.is_available():
+            raise RuntimeError("CUDA is not available")
+        raise RuntimeError("In-place CUDA operation requires input tensor to be on CUDA device")
+
+    if not other.is_cuda:
+        other = other.cuda()
+
+    # Use contiguous() before view() to handle non-contiguous tensors from broadcasting
+    if not other.is_contiguous():
+        other = other.contiguous()
+
+    other_flat = other.view(-1)
+
+    a_ = from_dlpack(input_flat)
+    b_ = from_dlpack(other_flat)
+    c_ = torch.empty_like(a_)
+
+    cache_key = (a_.shape, b_.shape, c_.shape)
+    if cache_key not in custom_cache_add__Tensor:
+        custom_cache_add__Tensor[cache_key] = cute.compile(
+        add__Tensor_kernel_launch, a_, b_, c_
+    )
+
+    custom_cache[cache_key](a_, b_, c_)
+
+    return input_tensor
+
+
+### Example 2: Element-wise add scalar kernel
+# Helper to map torch dtype to cutlass type
+def get_cutlass_scalar(val, dtype):
+    if dtype == torch.float16:
+        return cutlass.Float16(float(val))
+    elif dtype == torch.bfloat16:
+        return cutlass.Bfloat16(float(val))
+    if dtype == torch.float32:
+        return cutlass.Float32(float(val))
+    elif dtype == torch.float64:
+        return cutlass.Float64(float(val))
+    elif dtype == torch.int32:
+        return cutlass.Int32(int(val))
+    elif dtype == torch.int64:
+        return cutlass.Int64(int(val))
+    else:
+        raise TypeError(f"Unsupported dtype: {dtype}")
+
+@cute.kernel
+def add__Scalar_kernel(gA: cute.Tensor, gC: cute.Tensor, scalar_val):
+    tidx, _, _ = cute.arch.thread_idx()
+    bidx, _, _ = cute.arch.block_idx()
+    bdim, _, _ = cute.arch.block_dim()
+    thread_idx = bidx * bdim + tidx
+    total_elements = gA.shape[0]
+    if thread_idx < total_elements:
+        gC[thread_idx] = gA[thread_idx] + scalar_val
+
+@cute.jit
+def add__Scalar_kernel_launch(mA: cute.Tensor, mC: cute.Tensor, scalar_val):
+    num_threads_per_block = 1024
+    total_elements = mA.shape[0]
+    num_blocks = (total_elements + num_threads_per_block - 1) // num_threads_per_block
+    kernel = add__Scalar_kernel(mA, mC, scalar_val)
+    kernel.launch(grid=(num_blocks, 1, 1), block=(num_threads_per_block, 1, 1))
+
+custom_cache_add__Scalar = {}
+
+def add__Scalar_kernel_impl(input_tensor, other, alpha=1):
+    # Cast scalar to tensor's dtype and apply alpha
+    if hasattr(other, 'item'):
+        other = other.item()
+    scalar_val = get_cutlass_scalar(other * alpha, input_tensor.dtype)
+
+    # Store original device and shape
+    original_device = input_tensor.device
     original_shape = input_tensor.shape
-    input_tensor = input_tensor.flatten()
-    if torch.is_tensor(other):
-        other = other.flatten()
 
     # Move to GPU if needed
     if not input_tensor.is_cuda:
@@ -197,43 +258,221 @@ def add_kernel_impl(*args, **kwargs):
             raise RuntimeError("CUDA is not available")
         input_tensor = input_tensor.cuda()
 
-    # Check if other is a tensor or scalar
-    if torch.is_tensor(other):
-        # Tensor + Tensor case
-        if not other.is_cuda:
-            if not torch.cuda.is_available():
-                raise RuntimeError("CUDA is not available")
-            other = other.cuda()
+    # Ensure contiguous and flatten
+    if not input_tensor.is_contiguous():
+        input_tensor = input_tensor.contiguous()
+    input_flat = input_tensor.view(-1)
 
-        output = torch.empty_like(input_tensor)
-        a_ = from_dlpack(input_tensor)
-        b_ = from_dlpack(other)
-        c_ = from_dlpack(output)
+    # Convert to DLPack
+    a_ = from_dlpack(input_flat)
+    result = torch.empty_like(input_flat)
+    c_ = from_dlpack(result)
 
-        add_tensor_kernel_launch_ = cute.compile(add_tensor_kernel_launch, a_, b_, c_)
-        add_tensor_kernel_launch_(a_, b_, c_)
+    # Cache kernel compilation
+    cache_key = (a_.shape, type(scalar_val))
+    if cache_key not in custom_cache_add__Scalar:
+        custom_cache_add__Scalar[cache_key] = cute.compile(
+            add__Scalar_kernel_launch, a_, c_, scalar_val
+        )
+
+    # Launch kernel
+    custom_cache[cache_key](a_, c_, scalar_val)
+
+    # Restore original shape
+    result = result.view(original_shape)
+
+    # Move back to original device if needed
+    if original_device.type != 'cuda':
+        result = result.cpu()
+
+    return result
+
+### Example 3: Batch matrix multiplication kernel
+import torch
+import cutlass
+import cutlass.cute as cute
+from cutlass.cute.runtime import from_dlpack
+
+@cute.kernel
+def addmm__default_cutedsl_kernel(
+    gBias: cute.Tensor,
+    gA: cute.Tensor,
+    gB: cute.Tensor,
+    gC: cute.Tensor,
+    beta,
+    alpha,
+    M,
+    N,
+    K,
+):
+    tidx, tidy, _ = cute.arch.thread_idx()
+    bidx, bidy, _ = cute.arch.block_idx()
+    bdimx, bdimy, _ = cute.arch.block_dim()
+
+    # Calculate global thread indices
+    row = bidy * bdimy + tidy
+    col = bidx * bdimx + tidx
+
+    if row < M and col < N:
+        # Compute matrix multiplication: A @ B
+        # acc should be the same type as the output tensor
+        acc = cutlass.Float64(0.0)
+        for k in range(K):
+            a_val = gA[row * K + k]
+            b_val = gB[k * N + col]
+            acc = acc + a_val * b_val
+        
+        # Apply alpha scaling to matrix multiplication result
+        mm_result = alpha * acc
+        
+        # Add beta-scaled bias
+        bias_val = gBias[row * N + col] if gBias.shape[0] > 1 else gBias[0]
+        result = beta * bias_val + mm_result
+        
+        gC[row * N + col] = gC._dtype(result)
+
+@cute.jit
+def addmm__default_kernel_launch(
+    mBias: cute.Tensor,
+    mA: cute.Tensor,
+    mB: cute.Tensor,
+    mC: cute.Tensor,
+    beta,
+    alpha,
+    M,
+    N,
+    K,
+):
+    # Configure thread block dimensions
+    block_size_x = 16
+    block_size_y = 16
+    
+    # Calculate grid dimensions
+    grid_x = (N + block_size_x - 1) // block_size_x
+    grid_y = (M + block_size_y - 1) // block_size_y
+    
+    kernel = addmm__default_cutedsl_kernel(
+        mBias, mA, mB, mC, beta, alpha, M, N, K
+    )
+    kernel.launch(
+        grid=(grid_x, grid_y, 1),
+        block=(block_size_x, block_size_y, 1)
+    )
+
+custom_cache_addmm__default = {}
+
+def addmm__default_kernel_impl(*args, **kwargs):
+    # Parse arguments
+    if len(args) >= 3:
+        bias = args[0]
+        mat1 = args[1]
+        mat2 = args[2]
+        beta = args[3] if len(args) > 3 else kwargs.get('beta', 1)
+        alpha = args[4] if len(args) > 4 else kwargs.get('alpha', 1)
     else:
-        # Tensor + Scalar case
-        # Convert scalar to Python float
-        if hasattr(other, 'item'):
-            scalar_val = other.item()
-        else:
-            scalar_val = other
+        bias = kwargs.get('input', args[0] if len(args) > 0 else None)
+        mat1 = kwargs.get('mat1', args[1] if len(args) > 1 else None)
+        mat2 = kwargs.get('mat2', args[2] if len(args) > 2 else None)
+        beta = kwargs.get('beta', 1)
+        alpha = kwargs.get('alpha', 1)
+    
+    if bias is None or mat1 is None or mat2 is None:
+        raise ValueError("addmm requires bias, mat1, and mat2 arguments")
+    
+    # Get matrix dimensions
+    M, K = mat1.shape
+    K2, N = mat2.shape
+    
+    if K != K2:
+        raise RuntimeError(f"Matrix dimensions don't match for multiplication: {mat1.shape} @ {mat2.shape}")
+    
+    # Store original devices and shapes
+    original_device = bias.device
+    
+    # Move tensors to GPU if needed
+    if not bias.is_cuda:
+        if not torch.cuda.is_available():
+            raise RuntimeError("CUDA is not available")
+        bias = bias.cuda()
+    
+    if not mat1.is_cuda:
+        if not torch.cuda.is_available():
+            raise RuntimeError("CUDA is not available")
+        mat1 = mat1.cuda()
+    
+    if not mat2.is_cuda:
+        if not torch.cuda.is_available():
+            raise RuntimeError("CUDA is not available")
+        mat2 = mat2.cuda()
+    
+    # Ensure all tensors are contiguous
+    if not bias.is_contiguous():
+        bias = bias.contiguous()
+    if not mat1.is_contiguous():
+        mat1 = mat1.contiguous()
+    if not mat2.is_contiguous():
+        mat2 = mat2.contiguous()
+    
+    # Handle bias broadcasting
+    if bias.numel() == 1:
+        # Scalar bias - expand to full size
+        bias_flat = bias.view(-1)
+    elif bias.shape == (M, N):
+        # Full matrix bias
+        bias_flat = bias.view(-1)
+    elif bias.shape == (N,):
+        # Row vector bias - broadcast to (M, N)
+        bias = bias.unsqueeze(0).expand(M, N)
+        bias_flat = bias.contiguous().view(-1)
+    elif bias.shape == (M, 1):
+        # Column vector bias - broadcast to (M, N)
+        bias = bias.expand(M, N)
+        bias_flat = bias.contiguous().view(-1)
+    else:
+        raise RuntimeError(f"Bias shape {bias.shape} cannot be broadcast to result shape ({M}, {N})")
+    
+    # Flatten matrices
+    mat1_flat = mat1.view(-1)
+    mat2_flat = mat2.view(-1)
+    
+    # Create output tensor
+    result = torch.empty(M * N, dtype=bias.dtype, device=bias.device)
 
-        output = torch.empty_like(input_tensor)
-        a_ = from_dlpack(input_tensor)
-        c_ = from_dlpack(output)
+    # Convert to DLPack
+    bias_dl = from_dlpack(bias_flat)
+    mat1_dl = from_dlpack(mat1_flat)
+    mat2_dl = from_dlpack(mat2_flat)
+    result_dl = from_dlpack(result)
+    
+    # Convert scalars to cutlass types
+    beta_cutlass = beta
+    alpha_cutlass = alpha
+    
+    # Cache kernel compilation
+    cache_key = (bias_dl.shape, mat1_dl.shape, mat2_dl.shape, result_dl.shape, M, N, K)
+    if cache_key not in custom_cache_addmm__default:
+        custom_cache_addmm__default[cache_key] = cute.compile(
+            addmm__default_kernel_launch,
+            bias_dl, mat1_dl, mat2_dl, result_dl,
+            beta_cutlass, alpha_cutlass, M, N, K
+        )
+    
+    # Launch kernel
+    custom_cache_addmm__default[cache_key](
+        bias_dl, mat1_dl, mat2_dl, result_dl,
+        beta_cutlass, alpha_cutlass, M, N, K
+    )
+    
+    # Reshape result to output shape
+    result = result.view(M, N)
+    
+    # Move back to original device if needed
+    if original_device.type != 'cuda':
+        result = result.cpu()
+    
+    return result
 
-        add_scalar_kernel_launch_ = cute.compile(add_scalar_kernel_launch, a_, c_, scalar_val)
-        add_scalar_kernel_launch_(a_, c_, scalar_val)
-
-    # Move result back to original device
-    if original_device != output.device:
-        output = output.to(original_device)
-
-    output = output.reshape(original_shape)
-
-    return output"""
+"""
 }
 
 HELION_KERNEL_PROMPT = """Generate a Helion kernel for: {op_name}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "pandas",
     "datasets",
     "tenacity",
+    "nvidia-cutlass-dsl",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This PR introduces several improvements to BackendBench, focusing on enhanced support for the CuTe DSL and bug fixes across the LLM backend and operator naming logic.

Key Changes:
- Refined the CuTe DSL prompt to include DSL-specific requirements, common errors to avoid, and additional example code.
Achieved 100% correctness on multiple kernels for the add and relu operators.
- Fixed an issue where generation would break if an assertion is triggered. The backend now continues generation, improving robustness.
- Corrected folder operator overload naming conversion (e.g., add___Tensor now correctly maps to add_.Tensor instead of add._Tensor).

Results:
```
# BackendBench Run Summary

## Command
python -m BackendBench.scripts.main --suite torchbench --topn 5 --backend llm --ops add --dsl cutedsl

## Results

| Metric | Value |
|--------|-------|
| Correctness Score | 1.00 |
| Performance Score (geomean speedup) | 0.31 |
| Perf@1.0 Score | 0.20 |

### Metric Descriptions

- **Correctness Score**: Mean pass rate over all operators
- **Performance Score**: Geometric mean speedup over all operators
- **Perf@1.0 Score**: Rate of correct samples with a speedup greater than 1.0

## Output Files

The following files are saved in this directory:

- `full_results.json`: Complete test results for all operators
- `operator_summary.csv`: Operator-level summary statistics
- `failed_tests.json`: Log of failed tests (if any)
- `OVERALL_SUMMARY.md`: This file
### Operator Speedups vs Eager in Descending Order

| Operator | Correctness Ratio | Speedup vs Eager |
|----------|-----------|----------------|
| add.Scalar | 100.0000% | 1.0401x|
| add_.Tensor | 100.0000% | 0.7998x|
| add.Tensor | 100.0000% | 0.6495x|
| addcmul.default | 100.0000% | 0.2738x|
| addmm.default | 100.0000% | 0.0201x|
```

```
# BackendBench Run Summary

## Command
python -m BackendBench.scripts.main --suite torchbench --topn 5 --backend llm --ops relu --dsl cutedsl

## Results

| Metric | Value |
|--------|-------|
| Correctness Score | 1.00 |
| Performance Score (geomean speedup) | 0.62 |
| Perf@1.0 Score | 0.00 |

### Metric Descriptions

- **Correctness Score**: Mean pass rate over all operators
- **Performance Score**: Geometric mean speedup over all operators
- **Perf@1.0 Score**: Rate of correct samples with a speedup greater than 1.0

## Output Files

The following files are saved in this directory:

- `full_results.json`: Complete test results for all operators
- `operator_summary.csv`: Operator-level summary statistics
- `failed_tests.json`: Log of failed tests (if any)
- `OVERALL_SUMMARY.md`: This file
### Operator Speedups vs Eager in Descending Order

| Operator | Correctness Ratio | Speedup vs Eager |
|----------|-----------|----------------|
| leaky_relu.default | 100.0000% | 0.7085x|
| relu_.default | 100.0000% | 0.6494x|
| relu.default | 100.0000% | 0.6415x|
| leaky_relu_.default | 100.0000% | 0.5016x|
```